### PR TITLE
Register action for blocker clicked

### DIFF
--- a/shared/BSML/Components/ModalView.hpp
+++ b/shared/BSML/Components/ModalView.hpp
@@ -7,6 +7,7 @@ DECLARE_CLASS_CODEGEN(BSML, ModalView, HMUI::ModalView,
     DECLARE_INSTANCE_FIELD(Il2CppObject*, host);
     DECLARE_INSTANCE_FIELD(bool, moveToCenter);
     DECLARE_INSTANCE_FIELD(bool, dismissOnBlockerClicked);
+    DECLARE_INSTANCE_METHOD(void, Awake);
 
     public:
     DECLARE_INSTANCE_METHOD(void, Show);

--- a/src/BSML/Components/ModalView.cpp
+++ b/src/BSML/Components/ModalView.cpp
@@ -1,8 +1,13 @@
 #include "BSML/Components/ModalView.hpp"
+#include "Helpers/delegates.hpp"
 
 DEFINE_TYPE(BSML, ModalView);
 
 namespace BSML {
+    void ModalView::Awake() {
+        add_blockerClickedEvent(MakeSystemAction(this, ___BlockerClicked_MethodRegistrator.info));
+    }
+
     void ModalView::Show() {
         this->::HMUI::ModalView::Show(true, moveToCenter, nullptr);
     }


### PR DESCRIPTION
This fixes a bug where clicking on the blocker doesn't do anything