### PR TITLE
Implement Gradient Text Tag

### DIFF
--- a/shared/BSML/Components/TextGradientUpdater.hpp
+++ b/shared/BSML/Components/TextGradientUpdater.hpp
@@ -42,6 +42,8 @@ DECLARE_CLASS_CODEGEN(BSML, TextGradientUpdater, UnityEngine::MonoBehaviour,
     DECLARE_INSTANCE_FIELD(TMPro::TMP_Text*, text);
     DECLARE_INSTANCE_FIELD(float, scrollSpeed);
     DECLARE_INSTANCE_FIELD(float, scrollRepeat);
+    DECLARE_INSTANCE_FIELD(float, stepSize);
+    DECLARE_INSTANCE_FIELD(bool, fixedStep);
     DECLARE_INSTANCE_FIELD(float, currentPos);
 
     DECLARE_INSTANCE_METHOD(void, Awake);

--- a/shared/BSML/Components/TextGradientUpdater.hpp
+++ b/shared/BSML/Components/TextGradientUpdater.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "custom-types/shared/macros.hpp"
+#include "TMPro/TMP_Text.hpp"
+#include "UnityEngine/MonoBehaviour.hpp"
+
+namespace BSML {
+    /// @brief Gradient class, if you want custom Gradient behaviour then implement your own class and set it on the GradientUpdater using the set_gradient method
+    class Gradient {
+        public:
+            /// @brief Sample the gradient represented by this instance
+            /// @param t where to sample
+            /// @return UnityEngine Color32
+            virtual UnityEngine::Color32 Sample(float t) const = 0;
+            static Gradient* Parse(std::string_view str);
+            virtual ~Gradient() {};
+    };
+
+    /// @brief This type really only exists to speed up the math if you just input 2 colors, mostly for non-animated gradients
+    class SimpleTwoColorGradient : public Gradient {
+        public:
+            /// @brief Lerps between the start and end colors
+            /// @param t lerp distance
+            /// @return UnityEngine Color32
+            UnityEngine::Color32 Sample(float t) const override;
+            UnityEngine::Color32 start;
+            UnityEngine::Color32 end;
+    };
+
+    /// @brief Color gradient that samples from the passed vector
+    class SimpleColorGradient : public Gradient {
+        public:
+            /// @brief Lerps between the colors in the vector
+            /// @param t lerp distance
+            /// @return UnityEngine Color32
+            UnityEngine::Color32 Sample(float t) const override;
+            std::vector<UnityEngine::Color32> colors;
+    };
+}
+
+DECLARE_CLASS_CODEGEN(BSML, TextGradientUpdater, UnityEngine::MonoBehaviour,
+    DECLARE_INSTANCE_FIELD(TMPro::TMP_Text*, text);
+    DECLARE_INSTANCE_FIELD(float, scrollSpeed);
+    DECLARE_INSTANCE_FIELD(float, scrollRepeat);
+    DECLARE_INSTANCE_FIELD(float, currentPos);
+
+    DECLARE_INSTANCE_METHOD(void, Awake);
+    DECLARE_INSTANCE_METHOD(void, OnDestroy);
+    DECLARE_INSTANCE_METHOD(void, LateUpdate);
+    DECLARE_CTOR(ctor);
+    public:
+        Gradient* get_gradient();
+        void set_gradient(Gradient* gradient);
+    private:
+        Gradient* gradient;
+)
+

--- a/shared/BSML/Tags/GradientTextTag.hpp
+++ b/shared/BSML/Tags/GradientTextTag.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "TextTag.hpp"
+
+namespace BSML {
+    class GradientTextTag : public TextTag {
+        public:
+            GradientTextTag() : TextTag() {}
+        protected:
+            virtual UnityEngine::GameObject* CreateObject(UnityEngine::Transform* parent) const override;
+    };
+}

--- a/shared/BSML/TypeHandlers/TextGradientUpdaterHandler.hpp
+++ b/shared/BSML/TypeHandlers/TextGradientUpdaterHandler.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "TypeHandler.hpp"
+#include "../Components/TextGradientUpdater.hpp"
+
+namespace BSML {
+    class TextGradientUpdaterHandler : public TypeHandler<BSML::TextGradientUpdater*> {
+        public:
+            using Base = TypeHandler<BSML::TextGradientUpdater*>;
+            TextGradientUpdaterHandler() : Base() {}
+
+            virtual Base::PropMap get_props() const override;
+            virtual Base::SetterMap get_setters() const override;
+    };
+}

--- a/shared/StringParseHelper.hpp
+++ b/shared/StringParseHelper.hpp
@@ -8,6 +8,7 @@
 
 struct StringParseHelper : std::string_view {
     // pass the normal constructors through to the base, these are the only ones we need
+    StringParseHelper(const std::string_view& str) : std::string_view(str) {}
     StringParseHelper(const char* str) : std::string_view(str) {}
     StringParseHelper(const char* str, size_type len) : std::string_view(str, len) {}
     StringParseHelper(const std::string& str) : std::string_view(str.c_str(), str.size()) {}

--- a/src/BSML/Components/TextGradientUpdater.cpp
+++ b/src/BSML/Components/TextGradientUpdater.cpp
@@ -1,0 +1,128 @@
+#include "BSML/Components/TextGradientUpdater.hpp"
+#include "logging.hpp"
+#include "StringParseHelper.hpp"
+
+#include "TMPro/TMP_TextInfo.hpp"
+#include "TMPro/TMP_VertexDataUpdateFlags.hpp"
+#include "UnityEngine/Mesh.hpp"
+#include "UnityEngine/Time.hpp"
+
+DEFINE_TYPE(BSML, TextGradientUpdater);
+
+UnityEngine::Color32 operator+(UnityEngine::Color32 lhs, UnityEngine::Color32 rhs) {
+    return {
+        static_cast<uint8_t>(std::clamp(lhs.r + rhs.r, 0, 255)),
+        static_cast<uint8_t>(std::clamp(lhs.g + rhs.g, 0, 255)),
+        static_cast<uint8_t>(std::clamp(lhs.b + rhs.b, 0, 255)),
+        static_cast<uint8_t>(std::clamp(lhs.a + rhs.a, 0, 255))
+    };
+}
+UnityEngine::Color32 operator*(UnityEngine::Color32 lhs, float rhs) {
+    return {
+        static_cast<uint8_t>(std::clamp((int)(lhs.r * rhs), 0, 255)),
+        static_cast<uint8_t>(std::clamp((int)(lhs.g * rhs), 0, 255)),
+        static_cast<uint8_t>(std::clamp((int)(lhs.b * rhs), 0, 255)),
+        static_cast<uint8_t>(std::clamp((int)(lhs.a * rhs), 0, 255))
+    };
+}
+
+inline UnityEngine::Color32 operator*(float lhs, UnityEngine::Color32 rhs) {
+    return rhs * lhs;
+}
+
+namespace BSML {
+    void TextGradientUpdater::ctor() {
+        scrollSpeed = 1;
+        scrollRepeat = 1;
+        gradient = nullptr;
+    }
+
+    void TextGradientUpdater::set_gradient(Gradient* gradient) {
+        if (this->gradient) delete this->gradient;
+        this->gradient = gradient;
+    }
+
+    Gradient* TextGradientUpdater::get_gradient() { return gradient; }
+
+    void TextGradientUpdater::Awake() {
+        text = GetComponent<TMPro::TMP_Text*>();
+    }
+
+    void TextGradientUpdater::OnDestroy() {
+        delete gradient;
+        gradient = nullptr;
+    }
+
+    void TextGradientUpdater::LateUpdate() {
+        if (text && text->m_CachedPtr.m_value && gradient) {
+            // TODO: check if it's possible to implement something where the colors only get set once if scrollSpeed == 0
+            auto textInfo = text->get_textInfo();
+            auto characterCount = textInfo->characterCount;
+            if (characterCount > 0) {
+                currentPos = std::fmod(currentPos + UnityEngine::Time::get_deltaTime() * scrollSpeed, 1.0f);
+                int materialCount = textInfo->materialCount;
+                if (scrollRepeat == 0) {
+                    auto col = gradient->Sample(currentPos);
+                    for (int i = 0; i < materialCount; i++) {
+                        for (auto& c : textInfo->meshInfo[i].colors32) c = col;
+                    }
+                } else {
+                    for (int i = 0; i < materialCount; i++) {
+                        auto& colors = textInfo->meshInfo[i].colors32;
+                        auto size = colors.size();
+                        for (int j = 0; j < size; j++) {
+                            float t = (float)j / (float)size;
+                            colors[j] = gradient->Sample(currentPos + t * scrollRepeat);
+                        }
+                    }
+                }
+
+                text->UpdateVertexData(TMPro::TMP_VertexDataUpdateFlags::Colors32);
+            }
+        }
+    }
+    
+    UnityEngine::Color32 SimpleTwoColorGradient::Sample(float t) const {
+        return t * end + (1 - t) * start;
+    }
+
+    UnityEngine::Color32 SimpleColorGradient::Sample(float t) const {
+        if (colors.empty()) return {255, 255, 255, 255};
+        if (colors.size() == 1) return colors.at(0); 
+        t = std::fmod(t, 1.0f);
+
+        float i_unfloored = t * (colors.size() - 1);
+        int i = std::floor(i_unfloored);
+
+        if (i < colors.size() - 1) {
+            float subT = std::fmod(i_unfloored, 1.0f);
+            return (1 - subT) * colors[i] + subT * colors[i + 1];
+        } else {
+            return colors[i];
+        }
+    }
+
+    Gradient* Gradient::Parse(std::string_view str) {
+        std::vector<StringParseHelper> gradientStrings{};
+        char separator = ';';
+        std::size_t start = 0, end = 0;
+        while ((end = str.find(separator, start)) != std::string::npos) {
+            gradientStrings.push_back(StringParseHelper(str.substr(start, end - start)));
+            start = end + 1;
+        }
+        gradientStrings.push_back(str.substr(start));
+
+        if (gradientStrings.size() == 2) {
+            auto gradient = new SimpleTwoColorGradient();
+            gradient->start = gradientStrings.at(0);
+            gradient->end = gradientStrings.at(1);
+            return gradient;
+        } else {
+            auto gradient = new SimpleColorGradient();
+            for (auto c : gradientStrings) {
+                gradient->colors.emplace_back(c);
+            }
+            return gradient;
+        }
+    }
+}

--- a/src/BSML/Components/TextGradientUpdater.cpp
+++ b/src/BSML/Components/TextGradientUpdater.cpp
@@ -32,7 +32,7 @@ inline UnityEngine::Color32 operator*(float lhs, UnityEngine::Color32 rhs) {
 
 namespace BSML {
     void TextGradientUpdater::ctor() {
-        scrollSpeed = 1;
+        scrollSpeed = 0;
         scrollRepeat = 1;
         gradient = nullptr;
     }

--- a/src/BSML/Components/TextGradientUpdater.cpp
+++ b/src/BSML/Components/TextGradientUpdater.cpp
@@ -34,6 +34,8 @@ namespace BSML {
     void TextGradientUpdater::ctor() {
         scrollSpeed = 0;
         scrollRepeat = 1;
+        stepSize = 1;
+        fixedStep = false;
         gradient = nullptr;
     }
 
@@ -70,9 +72,16 @@ namespace BSML {
                     for (int i = 0; i < materialCount; i++) {
                         auto& colors = textInfo->meshInfo[i].colors32;
                         auto size = colors.size();
-                        for (int j = 0; j < size; j++) {
-                            float t = (float)j / (float)size;
-                            colors[j] = gradient->Sample(currentPos + t * scrollRepeat);
+                        if (fixedStep) {
+                            for (int j = 0; j < size; j++) {
+                                float t = j * stepSize * 0.01f;
+                                colors[j] = gradient->Sample(currentPos + t);
+                            }
+                        } else {
+                            for (int j = 0; j < size; j++) {
+                                float t = (float)j / (float)size;
+                                colors[j] = gradient->Sample(currentPos + t * scrollRepeat);
+                            }
                         }
                     }
                 }

--- a/src/BSML/Tags/GradientTextTag.cpp
+++ b/src/BSML/Tags/GradientTextTag.cpp
@@ -1,0 +1,14 @@
+#include "BSML/Tags/GradientTextTag.hpp"
+#include "BSML/Components/TextGradientUpdater.hpp"
+#include "logging.hpp"
+
+namespace BSML {
+    static BSMLNodeParser<GradientTextTag> textTagParser({"gradient-text"});
+
+    UnityEngine::GameObject* GradientTextTag::CreateObject(UnityEngine::Transform* parent) const {
+        DEBUG("Creating Gradient Text");
+        auto gameObject = TextTag::CreateObject(parent);
+        gameObject->AddComponent<BSML::TextGradientUpdater*>();
+        return gameObject;
+    }
+}

--- a/src/BSML/TypeHandlers/TextGradientUpdaterHandler.cpp
+++ b/src/BSML/TypeHandlers/TextGradientUpdaterHandler.cpp
@@ -1,0 +1,21 @@
+#include "BSML/TypeHandlers/TextGradientUpdaterHandler.hpp"
+
+namespace BSML {
+    static TextGradientUpdaterHandler textGradientUpdaterHandler{};
+
+    TextGradientUpdaterHandler::Base::PropMap TextGradientUpdaterHandler::get_props() const {
+        return {
+            { "gradientScrollSpeed", {"gradient-speed", "gradient-scroll-speed"}},
+            { "gradientScrollRepeat", {"gradient-section", "gradient-scroll-section", "gradient-repeat"}},
+            { "gradientColors", {"gradient", "gradient-colors"}}
+        };
+    }
+
+    TextGradientUpdaterHandler::Base::SetterMap TextGradientUpdaterHandler::get_setters() const {
+        return {
+            { "gradientScrollSpeed",    [](auto component, auto value){ component->scrollSpeed = value; }},
+            { "gradientScrollRepeat",   [](auto component, auto value){ component->scrollRepeat = value; }},
+            { "gradientColors",         [](auto component, auto value){ component->set_gradient(BSML::Gradient::Parse(value)); }}
+        };
+    }
+}

--- a/src/BSML/TypeHandlers/TextGradientUpdaterHandler.cpp
+++ b/src/BSML/TypeHandlers/TextGradientUpdaterHandler.cpp
@@ -5,9 +5,9 @@ namespace BSML {
 
     TextGradientUpdaterHandler::Base::PropMap TextGradientUpdaterHandler::get_props() const {
         return {
-            { "gradientScrollSpeed", {"gradient-speed", "gradient-scroll-speed"}},
-            { "gradientScrollRepeat", {"gradient-section", "gradient-scroll-section", "gradient-repeat"}},
-            { "gradientColors", {"gradient", "gradient-colors"}}
+            { "gradientScrollSpeed",  {"gradient-speed", "gradient-scroll-speed"}},
+            { "gradientScrollRepeat", {"gradient-repeat", "gradient-scroll-repeat"}},
+            { "gradientColors",       {"gradient-colors", "gradient"}}
         };
     }
 

--- a/src/BSML/TypeHandlers/TextGradientUpdaterHandler.cpp
+++ b/src/BSML/TypeHandlers/TextGradientUpdaterHandler.cpp
@@ -7,7 +7,9 @@ namespace BSML {
         return {
             { "gradientScrollSpeed",  {"gradient-speed", "gradient-scroll-speed"}},
             { "gradientScrollRepeat", {"gradient-repeat", "gradient-scroll-repeat"}},
-            { "gradientColors",       {"gradient-colors", "gradient"}}
+            { "gradientColors",       {"gradient-colors", "gradient"}},
+            { "gradientFixedStep",    {"gradient-fixed-step"}},
+            { "gradientStepSize",     {"gradient-step-size", "gradient-fixed-step-size"}}
         };
     }
 
@@ -15,7 +17,9 @@ namespace BSML {
         return {
             { "gradientScrollSpeed",    [](auto component, auto value){ component->scrollSpeed = value; }},
             { "gradientScrollRepeat",   [](auto component, auto value){ component->scrollRepeat = value; }},
-            { "gradientColors",         [](auto component, auto value){ component->set_gradient(BSML::Gradient::Parse(value)); }}
+            { "gradientColors",         [](auto component, auto value){ component->set_gradient(BSML::Gradient::Parse(value)); }},
+            { "gradientFixedStep",      [](auto component, auto value){ component->fixedStep = value; }},
+            { "gradientStepSize",       [](auto component, auto value){ component->stepSize = value; }}
         };
     }
 }


### PR DESCRIPTION
Implements a text tag flavour that scrolls a color gradient across it's face.
The following options are available:
 - `gradient-colors` for the gradient, which is a list of `;` seperated html colors
 - `gradient-speed` for how fast the color will scroll, scroll speed is 0 by default
 - `gradient-repeat` for how often the gradient repeats. 0 can be used for making the entire text 1 solid color sampled from the gradient
 - `gradient-fixed-step` for if you want to just fixed step through the gradient, instead of it being dependent on string length
 - `gradient-step-size` for how fast to step through the gradient when `gradient-fixed-step` is enabled 