### PR TITLE
Feat/gameplay open

### DIFF
--- a/shared/BSML/GameplaySetup/GameplaySetupMenu.hpp
+++ b/shared/BSML/GameplaySetup/GameplaySetupMenu.hpp
@@ -5,39 +5,11 @@
 #include "MenuType.hpp"
 #include <string>
 
-#define DECLARE_INSTANCE_CPP_ENUM_FIELD(type_, enumType_, name_) \
-static_assert(sizeof(type_) == sizeof(enumType_), "size mismatch"); \
-private: \
-struct ___FieldRegistrator_##name_ : ::custom_types::FieldRegistrator { \
-    ___FieldRegistrator_##name_() { \
-        ___TargetType::___TypeRegistration::addField(this); \
-    } \
-    constexpr const char* name() const override { \
-        return #name_; \
-    } \
-    const Il2CppType* type() const override { \
-        ::il2cpp_functions::Init(); \
-        return ::il2cpp_functions::class_get_type(::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<type_>::get()); \
-    } \
-    constexpr uint16_t fieldAttributes() const override { \
-        return FIELD_ATTRIBUTE_PUBLIC; \
-    } \
-    constexpr size_t size() const override { \
-        return sizeof(type_); \
-    } \
-    int32_t offset() const override { \
-        return offsetof(___TargetType, name_); \
-    } \
-}; \
-static inline ___FieldRegistrator_##name_ ___##name_##_FieldRegistrator; \
-public: \
-enumType_ name_
-
 DECLARE_CLASS_CODEGEN(BSML, GameplaySetupMenu, Il2CppObject,
     DECLARE_INSTANCE_FIELD(StringW, name);
     DECLARE_INSTANCE_FIELD(StringW, content_key);
     DECLARE_INSTANCE_FIELD(Il2CppObject*, host);
-    DECLARE_INSTANCE_CPP_ENUM_FIELD(int, MenuType, menuType);
+    DECLARE_INSTANCE_FIELD(MenuType, menuType);
     DECLARE_INSTANCE_FIELD(Tab*, tab);
 
     DECLARE_INSTANCE_METHOD(bool, get_visible);
@@ -52,6 +24,6 @@ DECLARE_CLASS_CODEGEN(BSML, GameplaySetupMenu, Il2CppObject,
         bool get_content(std::string_view& content);
 
         bool IsMenuType(BSML::MenuType toCheck);
-    
+
         DECLARE_DEFAULT_CTOR();
 )

--- a/shared/BSML/GameplaySetup/MenuType.hpp
+++ b/shared/BSML/GameplaySetup/MenuType.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "beatsaber-hook/shared/utils/il2cpp-type-check.hpp"
 namespace BSML {
     enum class MenuType {
         None = 0,
@@ -10,8 +11,16 @@ namespace BSML {
         All = Solo | Online | Campaign | Custom
     };
     bool operator!(const MenuType& type);
-    MenuType operator |(const MenuType& lhs, const MenuType& rhs); 
-    MenuType& operator |=(MenuType& lhs, const MenuType& rhs); 
-    MenuType operator &(const MenuType& lhs, const MenuType& rhs); 
-    MenuType& operator &=(MenuType& lhs, const MenuType& rhs); 
+    MenuType operator |(const MenuType& lhs, const MenuType& rhs);
+    MenuType& operator |=(MenuType& lhs, const MenuType& rhs);
+    MenuType operator &(const MenuType& lhs, const MenuType& rhs);
+    MenuType& operator &=(MenuType& lhs, const MenuType& rhs);
 }
+
+template<>
+struct ::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<BSML::MenuType> {
+    static inline Il2CppClass* get() {
+        return classof(int);
+    }
+};
+static_assert(sizeof(BSML::MenuType) == sizeof(int));

--- a/src/BSML/GameplaySetup/GameplaySetup.cpp
+++ b/src/BSML/GameplaySetup/GameplaySetup.cpp
@@ -92,13 +92,13 @@ namespace BSML {
     }
 
     void GameplaySetup::GameplaySetupDidDeactivate(bool removedFromHierarchy, bool screenSystemDisabling) {
-        DEBUG("DidDeactivate");
-        tabSelector->textSegmentedControl->SelectCellWithNumber(0);
-        DEBUG("disable vanillaTab");
-        vanillaTab->get_gameObject()->SetActive(true);
-        DEBUG("disable modsTab");
-        modsTab->get_gameObject()->SetActive(false);
-        DEBUG("Done");
+        DEBUG("DidDeactivate(removedFromHierarchy: {}, screenSystemDisabling: {})", removedFromHierarchy, screenSystemDisabling);
+
+        if (!screenSystemDisabling) {
+            tabSelector->textSegmentedControl->SelectCellWithNumber(0);
+            vanillaTab->get_gameObject()->SetActive(true);
+            modsTab->get_gameObject()->SetActive(false);
+        }
     }
 
     void GameplaySetup::ClickedOffModal() {


### PR DESCRIPTION
 - Cleans up how the MenuType enum is used
 - Keep the gameplay tab menu open on mods if going into a level, but still close it if backing out to the main menu