### PR TITLE
Implements some fixes & utilities regarding images & animations loading in BSML

### DIFF
--- a/shared/BSML/Animations/AnimationController.hpp
+++ b/shared/BSML/Animations/AnimationController.hpp
@@ -19,6 +19,9 @@ DECLARE_CLASS_CODEGEN(BSML, AnimationController, UnityEngine::MonoBehaviour,
     DECLARE_INSTANCE_METHOD(void, Update);
     
     public:
+        bool TryGetAnimationControllerData(StringW key, AnimationControllerData*& out);
+        bool Unregister(StringW key);
+        bool CanUnregister(AnimationControllerData* animationData);
         static AnimationController* get_instance();
         DECLARE_CTOR(ctor);
     protected:

--- a/shared/BSML/Animations/AnimationControllerData.hpp
+++ b/shared/BSML/Animations/AnimationControllerData.hpp
@@ -6,6 +6,10 @@
 #include "UnityEngine/Material.hpp"
 #include "UnityEngine/UI/Image.hpp"
 
+namespace BSML {
+    class AnimationStateUpdater;
+}
+
 DECLARE_CLASS_CODEGEN(BSML, AnimationControllerData, Il2CppObject,
     DECLARE_INSTANCE_FIELD(UnityEngine::Sprite*, sprite);
     DECLARE_INSTANCE_FIELD(int, uvIndex);
@@ -17,14 +21,21 @@ DECLARE_CLASS_CODEGEN(BSML, AnimationControllerData, Il2CppObject,
     DECLARE_INSTANCE_FIELD(List<UnityEngine::UI::Image*>*, activeImages);
     DECLARE_INSTANCE_METHOD(ListWrapper<UnityEngine::UI::Image*>, get_activeImages);
 
+    DECLARE_INSTANCE_METHOD(bool, IsBeingUsed);
+
     DECLARE_INSTANCE_FIELD(bool, _isPlaying);
     DECLARE_INSTANCE_METHOD(bool, get_isPlaying);
     DECLARE_INSTANCE_METHOD(void, set_isPlaying, bool value);
 
     DECLARE_DEFAULT_CTOR();
+    DECLARE_DTOR(dtor);
     public:
+        bool Add(AnimationStateUpdater* animationStateUpdater);
+        bool Remove(AnimationStateUpdater* animationStateUpdater);
+
         static AnimationControllerData* Make_new(UnityEngine::Texture2D* tex, ArrayW<UnityEngine::Rect> uvs, ArrayW<float> delays);
         void CheckFrame(unsigned long long now);
     private:
         unsigned long long lastSwitch;
+        std::set<AnimationStateUpdater*> animationStateUpdaters;
 )

--- a/shared/BSML/Animations/AnimationLoader.hpp
+++ b/shared/BSML/Animations/AnimationLoader.hpp
@@ -15,6 +15,7 @@ DECLARE_CLASS_CODEGEN(BSML, AnimationLoader, Il2CppObject,
             APNG,
         };
         static void Process(AnimationType type, ArrayW<uint8_t> data, std::function<void(UnityEngine::Texture2D*, ArrayW<UnityEngine::Rect>, ArrayW<float>)> onProcessed);
+        static void Process(AnimationType type, ArrayW<uint8_t> data, std::function<void(UnityEngine::Texture2D*, ArrayW<UnityEngine::Rect>, ArrayW<float>)> onProcessed, std::function<void()> onError);
         static custom_types::Helpers::Coroutine ProcessAnimationInfo(AnimationInfo* animationInfo, std::function<void(UnityEngine::Texture2D*, ArrayW<UnityEngine::Rect>, ArrayW<float>)> onProcessed);
         static int GetTextureSize(AnimationInfo* animationInfo, int i);
 )

--- a/shared/BSML/Animations/AnimationStateUpdater.hpp
+++ b/shared/BSML/Animations/AnimationStateUpdater.hpp
@@ -8,7 +8,7 @@
 
 DECLARE_CLASS_CODEGEN(BSML, AnimationStateUpdater, UnityEngine::MonoBehaviour,
     DECLARE_INSTANCE_FIELD(UnityEngine::UI::Image*, image);
-    DECLARE_INSTANCE_FIELD(AnimationControllerData*, controllerData);
+    DECLARE_INSTANCE_FIELD_PRIVATE(AnimationControllerData*, _controllerData);
     DECLARE_INSTANCE_METHOD(AnimationControllerData*, get_controllerData);
     DECLARE_INSTANCE_METHOD(void, set_controllerData, AnimationControllerData* value);
 

--- a/shared/BSML/Animations/GIF/GifDecoder.hpp
+++ b/shared/BSML/Animations/GIF/GifDecoder.hpp
@@ -7,7 +7,9 @@
 namespace BSML {
     class GifDecoder {
         public:
+            static custom_types::Helpers::Coroutine Process(ArrayW<uint8_t> data, std::function<void(AnimationInfo*)> onFinished, std::function<void()> onError);
             static custom_types::Helpers::Coroutine Process(ArrayW<uint8_t> data, std::function<void(AnimationInfo*)> onFinished);
             static void ProcessingThread(ArrayW<uint8_t> gifData, AnimationInfo* animationInfo);
+            static void ProcessingThread(ArrayW<uint8_t> gifData, AnimationInfo* animationInfo, std::function<void()> onError);
     };
 }

--- a/shared/Helpers/utilities.hpp
+++ b/shared/Helpers/utilities.hpp
@@ -82,6 +82,12 @@ namespace BSML::Utilities {
     /// @brief sets the sprite from a path, this does not yet bother with animated textures so it will only work with base textures
     /// @param image the image to set the sprite on
     /// @param path the path, basegame name, or URI to an image
+    /// @param cached whether to cache the resulting sprite or not
+    void SetImage(UnityEngine::UI::Image* image, StringW path, bool cached);
+
+    /// @brief sets the sprite from a path, this does not yet bother with animated textures so it will only work with base textures
+    /// @param image the image to set the sprite on
+    /// @param path the path, basegame name, or URI to an image
     /// @param loadingAnimation currently unused, but might eventually be used for a loading animation while stuff is downloading
     /// @param scaleOptions the scale options to use, if any
     /// @param onFinished a callback to call when the image is finished loading, if any
@@ -95,6 +101,16 @@ namespace BSML::Utilities {
     /// @param onFinished a callback to call when the image is finished loading, if any
     /// @param onError a callback to call when there was an error
     void SetImage(UnityEngine::UI::Image* image, StringW path, bool loadingAnimation, ScaleOptions scaleOptions, std::function<void()> onFinished, std::function<void(ImageLoadError)> onError);
+
+    /// @brief sets the sprite from a path, this does not yet bother with animated textures so it will only work with base textures
+    /// @param image the image to set the sprite on
+    /// @param path the path, basegame name, or URI to an image
+    /// @param loadingAnimation currently unused, but might eventually be used for a loading animation while stuff is downloading
+    /// @param scaleOptions the scale options to use, if any
+    /// @param cached whether to set the image and cache it, or to skip caching it if loaded newly. only works for static images, not for animated images
+    /// @param onFinished a callback to call when the image is finished loading, if any
+    /// @param onError a callback to call when there was an error
+    void SetImage(UnityEngine::UI::Image* image, StringW path, bool loadingAnimation, ScaleOptions scaleOptions, bool cached, std::function<void()> onFinished, std::function<void(ImageLoadError)> onError);
 
     /// @brief function to get data at a URI, this is not blocking as it dispatches a coroutine
     /// @param uri the URI to get data from

--- a/shared/Helpers/utilities.hpp
+++ b/shared/Helpers/utilities.hpp
@@ -69,6 +69,10 @@ namespace BSML::Utilities {
     /// @return downscaled sprite
     UnityEngine::Sprite* DownScaleSprite(UnityEngine::Sprite* sprite, const ScaleOptions& options);
 
+    /// @brief Removes an image from the internal cache if it exists, make sure it's not used anymore!
+    /// @param path the image to remove
+    /// @return whether the path was in the cache
+    bool RemoveImage(StringW path);
 
     /// @brief sets the sprite from a path, this does not yet bother with animated textures so it will only work with base textures
     /// @param image the image to set the sprite on

--- a/src/BSML/Animations/AnimationStateUpdater.cpp
+++ b/src/BSML/Animations/AnimationStateUpdater.cpp
@@ -4,34 +4,37 @@ DEFINE_TYPE(BSML, AnimationStateUpdater);
 
 namespace BSML {
     AnimationControllerData* AnimationStateUpdater::get_controllerData() {
-        return controllerData;
+        return _controllerData;
     }
 
     void AnimationStateUpdater::set_controllerData(AnimationControllerData* value) {
-        if (controllerData) {
+        if (_controllerData) {
             OnDisable();
+            _controllerData->Remove(this);
         }
-        controllerData = value;
+        _controllerData = value;
+        if (_controllerData) _controllerData->Add(this);
+
         if (get_isActiveAndEnabled()) {
             OnEnable();
         }
     }
 
     void AnimationStateUpdater::OnEnable() {
-        if (controllerData && image) {
-            controllerData->get_activeImages()->Add(image);
+        if (_controllerData && image) {
+            _controllerData->get_activeImages()->Add(image);
         }
     }
 
     void AnimationStateUpdater::OnDisable() {
-        if (controllerData && image) {
-            controllerData->get_activeImages()->Remove(image);
+        if (_controllerData && image) {
+            _controllerData->get_activeImages()->Remove(image);
         }
     }
 
     void AnimationStateUpdater::OnDestroy() {
-        if (controllerData && image) {
-            controllerData->get_activeImages()->Remove(image);
+        if (_controllerData && image) {
+            _controllerData->get_activeImages()->Remove(image);
         }
     }
 }

--- a/src/BSML/Parsing/BSMLParser.cpp
+++ b/src/BSML/Parsing/BSMLParser.cpp
@@ -52,6 +52,9 @@ namespace BSML {
         auto values = BSMLValue::MakeValues(host);
         for (auto& [key, value] : values) {
             INFO("Got value: {}", key);
+            INFO("finfo: {}", (bool)value->fieldInfo);
+            INFO("sinfo: {}", (bool)value->setterInfo);
+            INFO("ginfo: {}", (bool)value->getterInfo);
             parserParams->AddValue(key, value);
         }
 
@@ -71,7 +74,7 @@ namespace BSML {
         for (auto component : components) {
             delete component;
         }
-        
+
         components.clear();
 
         auto postParseMinfo = il2cpp_functions::class_get_method_from_name(host->klass, "PostParse", 0);
@@ -105,7 +108,7 @@ namespace BSML {
             delete component;
         }
         components.clear();
-        
+
         auto postParseMinfo = il2cpp_functions::class_get_method_from_name(host->klass, "PostParse", 0);
         if (postParseMinfo) il2cpp_utils::RunMethod(host, postParseMinfo);
 

--- a/src/Helpers/getters.cpp
+++ b/src/Helpers/getters.cpp
@@ -50,14 +50,14 @@ namespace BSML::Helpers {
         return hoverHintController.ptr();
     }
 
-    IVRPlatformHelper* platformHelper = nullptr;
+    SafePtr<IVRPlatformHelper> platformHelper;
     IVRPlatformHelper* GetIVRPlatformHelper()
     {
         if (!platformHelper)
             platformHelper = Resources::FindObjectsOfTypeAll<LevelCollectionTableView*>().First()->GetComponentInChildren<ScrollView*>()->platformHelper;
         if (!platformHelper)
             CacheNotFoundWarningLog(IVRPlatformHelper);
-        return platformHelper;
+        return platformHelper.ptr();
     }
 
     SafePtrUnity<TMP_FontAsset> mainTextFont;

--- a/src/Helpers/utilities.cpp
+++ b/src/Helpers/utilities.cpp
@@ -236,6 +236,17 @@ namespace BSML::Utilities {
         return bsmlSetImageCache.ptr();
     }
 
+    bool RemoveImage(StringW path) {
+        auto cache = get_bsmlSetImageCache();
+        UnityEngine::Sprite* img = nullptr;
+        if (cache->TryGetValue(path, byref(img))) {
+            cache->Remove(path);
+            if (img && img->m_CachedPtr.m_value) UnityEngine::Object::DestroyImmediate(img);
+            return true;
+        }
+        return false;
+    }
+
     void SetAndLoadImageAnimated(UnityEngine::UI::Image* image, StringW path, bool loadingAnimation, std::pair<bool, System::Uri*> uri, std::function<void()> onFinished, std::function<void(ImageLoadError)> onError) {
         auto animationController = AnimationController::get_instance();
 

--- a/src/Helpers/utilities.cpp
+++ b/src/Helpers/utilities.cpp
@@ -263,6 +263,7 @@ namespace BSML::Utilities {
         };
         if (animationController->registeredAnimations->TryGetValue(path, byref(data))) {
             stateUpdater->set_controllerData(animationControllerData);
+            if (onFinished) onFinished();
         } else {
             bool isGif = path->EndsWith("gif", System::StringComparison::OrdinalIgnoreCase) || (uri.first && uri.second->get_LocalPath()->EndsWith("gif", System::StringComparison::OrdinalIgnoreCase));
             auto animType = isGif ? AnimationLoader::AnimationType::GIF : AnimationLoader::AnimationType::APNG;

--- a/src/Helpers/utilities.cpp
+++ b/src/Helpers/utilities.cpp
@@ -384,7 +384,7 @@ namespace BSML::Utilities {
         if (IsAnimated(path) || (isUri && IsAnimated(uri->get_LocalPath()))) {
             SetAndLoadImageAnimated(image, path, loadingAnimation, {isUri, uri}, onFinished, onError);
         } else { // not animated
-            SetAndLoadImageNonAnimated(image, path, loadingAnimation, scaleOptions, {isUri, uri}, cached, onFinished, onError);
+            SetAndLoadImageNonAnimated(image, path, loadingAnimation, scaleOptions, cached, {isUri, uri}, onFinished, onError);
         }
     }
 

--- a/src/Helpers/utilities.cpp
+++ b/src/Helpers/utilities.cpp
@@ -286,7 +286,7 @@ namespace BSML::Utilities {
         }
     }
 
-    void SetandLoadImageNonAnimated(UnityEngine::UI::Image* image, StringW path, bool loadingAnimation, ScaleOptions scaleOptions, std::pair<bool, System::Uri*> uri, std::function<void()> onFinished, std::function<void(ImageLoadError)> onError) {
+    void SetAndLoadImageNonAnimated(UnityEngine::UI::Image* image, StringW path, bool loadingAnimation, ScaleOptions scaleOptions, std::pair<bool, System::Uri*> uri, std::function<void()> onFinished, std::function<void(ImageLoadError)> onError) {
         auto errorType = uri.first ? ImageLoadError::NetworkError : ImageLoadError::GetDataError;
         auto onDataFinished = [path, onFinished, onError, errorType, image, scaleOptions](ArrayW<uint8_t> data) {
             // somehow data was failed to be gotten
@@ -362,7 +362,7 @@ namespace BSML::Utilities {
         if (IsAnimated(path) || (isUri && IsAnimated(uri->get_LocalPath()))) {
             SetAndLoadImageAnimated(image, path, loadingAnimation, {isUri, uri}, onFinished, onError);
         } else { // not animated
-            SetandLoadImageNonAnimated(image, path, loadingAnimation, scaleOptions, {isUri, uri}, onFinished, onError);
+            SetAndLoadImageNonAnimated(image, path, loadingAnimation, scaleOptions, {isUri, uri}, onFinished, onError);
         }
     }
 
@@ -428,7 +428,7 @@ namespace BSML::Utilities {
                 }
             }
         }
-        
+
         myIter = nullptr;
         ::FieldInfo* field = nullptr;
         void* value = nullptr;
@@ -445,7 +445,7 @@ namespace BSML::Utilities {
 
         return CopyFieldsAndProperties(comp, other, klass->parent);
     }
-    
+
     /// based on https://answers.unity.com/questions/530178/how-to-get-a-component-from-an-object-and-add-it-t.html
     UnityEngine::Component* GetCopyOfComponent(UnityEngine::Component* comp, UnityEngine::Component* other) {
         auto klass = comp->klass;
@@ -470,7 +470,7 @@ namespace BSML::Utilities {
             }
             return blankSprite.ptr();
         }
-        
+
         SafePtrUnity<UnityEngine::Sprite> whitePixelSprite;
         UnityEngine::Sprite* GetWhitePixel() {
             if (!whitePixelSprite) {


### PR DESCRIPTION
 - Add method to be called on error loading image / animation
 - Allow forcibly removing images from the image cache
 - Gifs get cleaned up if nothing exists that uses their data
 - Made it so you can tell SetImage to not cache an image if you want to not do that