### PR TITLE
Implement menu registration with generic methods

### DIFF
--- a/shared/BSML.hpp
+++ b/shared/BSML.hpp
@@ -107,11 +107,11 @@ namespace BSML {
         bool RegisterGameplaySetupTab(std::string_view name, std::string_view content_key, Il2CppObject* host, MenuType menuType = MenuType::All);
 
         /// @brief register a tab for the gameplay setup menu
-        /// @param csType C# type of your component you want to register, should inherit MonoBehaviour!
         /// @param name the name to display
+        /// @param csType C# type of your component you want to register, should inherit MonoBehaviour!
         /// @param menuType where your tab should be displayed. Default is All
         /// @return true if successful, false if failed
-        bool RegisterGameplaySetupTab(System::Type* csType, std::string_view name, MenuType menuType = MenuType::All);
+        bool RegisterGameplaySetupTab(std::string_view name, System::Type* csType, MenuType menuType = MenuType::All);
 
         /// @brief concept to ensure the passed type has a void DidActivate(bool)
         template<typename T>
@@ -129,6 +129,13 @@ namespace BSML {
         static inline bool RegisterGameplaySetupTab(std::string_view name, MenuType menuType = MenuType::All) {
             return RegisterGameplaySetupTab(csTypeOf(T), name, menuType);
         }
+
+        /// @brief register a tab for the gameplay setup menu
+        /// @param name the name to display
+        /// @param didActivate callback ran when the tab is activated
+        /// @param menuType where your tab should be displayed. Default is All
+        /// @return true if successful, false if failed
+        bool RegisterGameplaySetupTab(std::string_view name, std::function<void(UnityEngine::GameObject*, bool)> didActivate, MenuType menuType = MenuType::All);
 
         /// @brief remove a tab from the settings menu
         /// @param name the name of the tab to remove

--- a/shared/BSML.hpp
+++ b/shared/BSML.hpp
@@ -137,7 +137,7 @@ namespace BSML {
         /// @param hoverhint the hoverhint for the button
         template<typename T>
         requires(std::is_convertible_v<T, HMUI::ViewController*>)
-        inline void RegisterMainMenu(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint) {
+        static inline void RegisterMainMenu(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint) {
             return RegisterMainMenuViewController(title, buttonText, hoverhint, csTypeOf(T));
         }
 
@@ -147,7 +147,7 @@ namespace BSML {
         /// @param hoverhint the hoverhint for the button
         template<typename T>
         requires(std::is_convertible_v<T, HMUI::FlowCoordinator*>)
-        inline void RegisterMainMenu(const std::string_view& buttonText, const std::string_view& hoverhint) {
+        static inline void RegisterMainMenu(const std::string_view& buttonText, const std::string_view& hoverhint) {
             return RegisterMainMenuFlowCoordinator(buttonText, hoverhint, csTypeOf(T));
         }
 
@@ -159,7 +159,7 @@ namespace BSML {
         /// @param viewControllerDidActivate the callback to execute
         template<typename T>
         requires(std::is_constructible_v<std::function<void(HMUI::ViewController*, bool, bool, bool)>, T>)
-        inline void RegisterMainMenu(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint, T viewControllerDidActivate = nullptr) {
+        static inline void RegisterMainMenu(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint, T viewControllerDidActivate = nullptr) {
             return RegisterMainMenuViewControllerMethod(title, buttonText, hoverhint, viewControllerDidActivate);
         }
     }

--- a/shared/BSML.hpp
+++ b/shared/BSML.hpp
@@ -1,20 +1,24 @@
 #pragma once
 
 #include "UnityEngine/Transform.hpp"
+#include "HMUI/ViewController.hpp"
+#include "HMUI/FlowCoordinator.hpp"
 #include "BSML/Parsing/BSMLParser.hpp"
 #include "BSML/MenuButtons/MenuButton.hpp"
 #include "BSML/GameplaySetup/MenuType.hpp"
 
+#include <functional>
+
 namespace BSML {
-    
-    /// @brief Intialize BSML for it's hooks 
+
+    /// @brief Intialize BSML for it's hooks
     void Init();
-    
-    /// @brief parse a string containing a BSML doc 
+
+    /// @brief parse a string containing a BSML doc
     /// @return BSMLNode pointer to parsed hierarchy
     std::shared_ptr<BSMLParser> parse(std::string_view str);
 
-    /// @brief parse a string containing a BSML doc 
+    /// @brief parse a string containing a BSML doc
     /// @param str the string to parse
     /// @param parent what to parent to
     /// @param host the host object, this would contain the various fields and properties your bsml expects to be able to access
@@ -29,12 +33,12 @@ namespace BSML {
         /// @param onClick what to run when you click the button
         /// @return the created MenuButton*, or nullptr if it failed
         MenuButton* RegisterMenuButton(std::string_view text, std::string_view hoverHint = "", std::function<void(void)> onClick = nullptr);
-    
+
         /// @brief register a menu button for the left main menu
         /// @param button the button to register
         /// @return true if successful, false if failed
         bool RegisterMenuButton(MenuButton* button);
-    
+
         /// @brief unregister a menu button for the left main menu
         /// @param button the button to unregister
         /// @return true if successful, false if failed
@@ -67,5 +71,58 @@ namespace BSML {
         /// @param name the name of the tab to remove
         /// @return true if successful, false if failed
         bool UnRegisterGameplaySetupTab(std::string_view name);
+
+        /// @brief Registers a main menu button that opens a flow coordinator
+        /// @param buttonText the text of the button
+        /// @param hoverhint the hover hint of the button
+        /// @param flowCoordinatorType csType of the flow coordinator
+        void RegisterMainMenuFlowCoordinator(const std::string_view& buttonText, const std::string_view& hoverhint, System::Type* flowCoordinatorType);
+
+        /// @brief Registers a main menu button that opens a view controller
+        /// @param title the title displayed above the view controller
+        /// @param buttonText the text of the button
+        /// @param hoverhint the hover hint of the button
+        /// @param viewControllerType csType of the flow coordinator
+        void RegisterMainMenuViewController(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint, System::Type* viewControllerType);
+
+        /// @brief Registers a main menu button that opens a view controller
+        /// @param title the title displayed above the view controller
+        /// @param buttonText the text of the button
+        /// @param hoverhint the hover hint of the button
+        /// @param viewControllerDidActivate callback ran when the view controller you want to create is opened
+        void RegisterMainMenuViewControllerMethod(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint, std::function<void(HMUI::ViewController*, bool, bool, bool)> viewControllerDidActivate);
+
+        /// @brief Register a view controller type to be displayed when clicking a main menu button
+        /// @tparam T the type of the view controller
+        /// @param title the title to be displayed above the view controller
+        /// @param buttonText the button text
+        /// @param hoverhint the hoverhint for the button
+        template<typename T>
+        requires(std::is_convertible_v<T, HMUI::ViewController*>)
+        inline void RegisterMainMenu(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint) {
+            return RegisterMainMenuViewController(title, buttonText, hoverhint, csTypeOf(T));
+        }
+
+        /// @brief Register a flow coordinator type to be displayed when clicking a main menu button
+        /// @tparam T the type of the flow coordinator
+        /// @param buttonText the button text
+        /// @param hoverhint the hoverhint for the button
+        template<typename T>
+        requires(std::is_convertible_v<T, HMUI::FlowCoordinator*>)
+        inline void RegisterMainMenu(const std::string_view& buttonText, const std::string_view& hoverhint) {
+            return RegisterMainMenuFlowCoordinator(buttonText, hoverhint, csTypeOf(T));
+        }
+
+        /// @brief Register a callback to run on a view controller when clicking a main menu button
+        /// @tparam T your method type
+        /// @param title the title to be displayed above the view controller
+        /// @param buttonText the button text
+        /// @param hoverhint the hoverhint for the button
+        /// @param viewControllerDidActivate the callback to execute
+        template<typename T>
+        requires(std::is_constructible_v<std::function<void(HMUI::ViewController*, bool, bool, bool)>, T>)
+        inline void RegisterMainMenu(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint, T viewControllerDidActivate = nullptr) {
+            return RegisterMainMenuViewControllerMethod(title, buttonText, hoverhint, viewControllerDidActivate);
+        }
     }
 }

--- a/shared/BSML.hpp
+++ b/shared/BSML.hpp
@@ -10,7 +10,6 @@
 #include <functional>
 
 namespace BSML {
-
     /// @brief Intialize BSML for it's hooks
     void Init();
 
@@ -124,5 +123,10 @@ namespace BSML {
         inline void RegisterMainMenu(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint, T viewControllerDidActivate = nullptr) {
             return RegisterMainMenuViewControllerMethod(title, buttonText, hoverhint, viewControllerDidActivate);
         }
+    }
+
+    namespace Events {
+        /// @brief Event that gets invoked right before MenuTransitionsHelper::RestartGame ( Game Restart )
+        extern UnorderedEventCallback<> onGameDidRestart;
     }
 }

--- a/shared/BSML.hpp
+++ b/shared/BSML.hpp
@@ -6,6 +6,7 @@
 #include "BSML/Parsing/BSMLParser.hpp"
 #include "BSML/MenuButtons/MenuButton.hpp"
 #include "BSML/GameplaySetup/MenuType.hpp"
+#include "BSML/MenuSource.hpp"
 
 #include <memory>
 #include <string>
@@ -104,6 +105,30 @@ namespace BSML {
         /// @param menuType where your tab should be displayed. Default is All
         /// @return true if successful, false if failed
         bool RegisterGameplaySetupTab(std::string_view name, std::string_view content_key, Il2CppObject* host, MenuType menuType = MenuType::All);
+
+        /// @brief register a tab for the gameplay setup menu
+        /// @param csType C# type of your component you want to register, should inherit MonoBehaviour!
+        /// @param name the name to display
+        /// @param menuType where your tab should be displayed. Default is All
+        /// @return true if successful, false if failed
+        bool RegisterGameplaySetupTab(System::Type* csType, std::string_view name, MenuType menuType = MenuType::All);
+
+        /// @brief concept to ensure the passed type has a void DidActivate(bool)
+        template<typename T>
+        concept WithDidActivate = requires(T a) {
+            { a->DidActivate(false) } -> std::same_as<void>;
+        };
+
+        /// @brief register a tab for the gameplay setup menu
+        /// @param csType C# type of your component you want to register
+        /// @param name the name to display
+        /// @param menuType where your tab should be displayed. Default is All
+        /// @return true if successful, false if failed
+        template<WithDidActivate T>
+        requires(std::is_convertible_v<T, UnityEngine::MonoBehaviour*>)
+        static inline bool RegisterGameplaySetupTab(std::string_view name, MenuType menuType = MenuType::All) {
+            return RegisterGameplaySetupTab(csTypeOf(T), name, menuType);
+        }
 
         /// @brief remove a tab from the settings menu
         /// @param name the name of the tab to remove

--- a/shared/BSML.hpp
+++ b/shared/BSML.hpp
@@ -7,6 +7,8 @@
 #include "BSML/MenuButtons/MenuButton.hpp"
 #include "BSML/GameplaySetup/MenuType.hpp"
 
+#include <memory>
+#include <string>
 #include <functional>
 
 namespace BSML {
@@ -51,6 +53,43 @@ namespace BSML {
         /// @param enableExtraButtons whether to enable the extra ok / cancel buttons
         /// @return true if successful, false if failed
         bool RegisterSettingsMenu(std::string_view name, std::string_view content_key, Il2CppObject* host, bool enableExtraButtons = false);
+
+        /// @brief register a menu for the settings menu
+        /// @param csType the type of your view controller, keep in mind this should inherit HMUI::ViewController*
+        /// @param name the name displayed for your settings
+        /// @param menuType what kind of source is used for the menu content
+        /// @param enableExtraButtons whether to enable the extra ok / cancel buttons
+        /// @throw throws if menuType is anything other than ViewController or FlowCoordinator
+        /// @return true if successful, false if failed
+        bool RegisterSettingsMenu(std::string_view name, System::Type* csType, MenuSource menuSource, bool enableExtraButtons = false);
+
+        /// @brief register a menu for the settings menu
+        /// @tparam T the type of your view controller, keep in mind this should inherit HMUI::ViewController*
+        /// @param name the name displayed for your settings
+        /// @param enableExtraButtons whether to enable the extra ok / cancel buttons
+        /// @return true if successful, false if failed
+        template<typename T>
+        requires(std::is_convertible_v<T, HMUI::ViewController*>)
+        static inline bool RegisterSettingsMenu(std::string_view name, bool enableExtraButtons = false) {
+            return RegisterSettingsMenu(name, csTypeOf(T), MenuSource::ViewController, enableExtraButtons);
+        }
+
+        /// @brief register a menu for the settings menu
+        /// @tparam T the type of your flowCoordinator, keep in mind this should inherit HMUI::FlowCoordinator*
+        /// @param name the name displayed for your settings
+        /// @return true if successful, false if failed
+        template<typename T>
+        requires(std::is_convertible_v<T, HMUI::FlowCoordinator*>)
+        static inline bool RegisterSettingsMenu(std::string_view name) {
+            return RegisterSettingsMenu(name, csTypeOf(T), MenuSource::FlowCoordinator, false);
+        }
+
+        /// @brief register a menu for the settings menu
+        /// @param name the name displayed for your settings
+        /// @param viewControllerDidActivate callback ran when the view controller you want to create is opened
+        /// @param enableExtraButtons whether to enable the extra ok / cancel buttons
+        /// @return true if successful, false if failed
+        bool RegisterSettingsMenu(std::string_view name, std::function<void(HMUI::ViewController*, bool, bool, bool)> viewControllerDidActivate, bool enableExtraButtons);
 
         /// @brief remove a menu from the settings menu
         /// @param host the host object used when registering your menu

--- a/shared/BSML/FlowCoordinators/MainMenuHolderFlowCoordinator.hpp
+++ b/shared/BSML/FlowCoordinators/MainMenuHolderFlowCoordinator.hpp
@@ -21,6 +21,7 @@ namespace BSML {
 
             MainMenuRegistration(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverHint, const System::Type* csType, const RegistrationType registrationType);
             MainMenuRegistration(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverHint, const std::function<void(HMUI::ViewController*, bool, bool, bool)> setupFunc);
+            ~MainMenuRegistration();
 
             void Present();
 
@@ -40,6 +41,7 @@ namespace BSML {
             friend class MainMenuHolderFlowCoordinator;
             friend void ::BSML::Register::AddMainMenuRegistration(MainMenuRegistration* reg);
 
+            void OnGameDidRestart();
             void PresentWithFlowCoordinator(HMUI::FlowCoordinator* presentOn);
             void PresentWithViewController(HMUI::FlowCoordinator* presentOn);
             void PresentWithMethod(HMUI::FlowCoordinator* presentOn);

--- a/shared/BSML/FlowCoordinators/MainMenuHolderFlowCoordinator.hpp
+++ b/shared/BSML/FlowCoordinators/MainMenuHolderFlowCoordinator.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "custom-types/shared/macros.hpp"
+#include "custom-types/shared/coroutine.hpp"
+#include "HMUI/FlowCoordinator.hpp"
+#include "HMUI/ViewController.hpp"
+
+namespace BSML {
+    class MainMenuRegistration;
+    namespace Register {
+        void AddMainMenuRegistration(MainMenuRegistration* reg);
+    }
+
+    class MainMenuRegistration {
+        public:
+            enum class RegistrationType {
+                FlowCoordinator,
+                ViewController,
+                Method
+            };
+
+            MainMenuRegistration(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverHint, const System::Type* csType, const RegistrationType registrationType);
+            MainMenuRegistration(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverHint, const std::function<void(HMUI::ViewController*, bool, bool, bool)> setupFunc);
+
+            void Present();
+
+            const std::string title;
+            const std::string buttonText;
+            const std::string hoverHint;
+            union {
+                HMUI::ViewController* viewController;
+                HMUI::FlowCoordinator* flowCoordinator;
+            };
+            const System::Type* csType;
+            const std::function<void(HMUI::ViewController*, bool, bool, bool)> setupFunc;
+            const RegistrationType registrationType;
+
+            static MainMenuRegistration* get_registration(const std::string_view& buttonText);
+        private:
+            friend class MainMenuHolderFlowCoordinator;
+            friend void ::BSML::Register::AddMainMenuRegistration(MainMenuRegistration* reg);
+
+            void PresentWithFlowCoordinator(HMUI::FlowCoordinator* presentOn);
+            void PresentWithViewController(HMUI::FlowCoordinator* presentOn);
+            void PresentWithMethod(HMUI::FlowCoordinator* presentOn);
+
+            static std::vector<MainMenuRegistration*> registrations;
+    };
+}
+
+DECLARE_CLASS_CODEGEN(BSML, MainMenuHolderFlowCoordinator, HMUI::FlowCoordinator,
+    DECLARE_INSTANCE_FIELD(HMUI::ViewController*, placeholder);
+    DECLARE_OVERRIDE_METHOD(void, DidActivate, il2cpp_utils::il2cpp_type_check::MetadataGetter<&HMUI::FlowCoordinator::DidActivate>::get(), bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling);
+    DECLARE_OVERRIDE_METHOD(void, BackButtonWasPressed, il2cpp_utils::il2cpp_type_check::MetadataGetter<&HMUI::FlowCoordinator::BackButtonWasPressed>::get(), HMUI::ViewController* topViewController);
+    private:
+        custom_types::Helpers::Coroutine EndOfFramePresentVC();
+        static SafePtrUnity<MainMenuHolderFlowCoordinator> instance;
+        static MainMenuHolderFlowCoordinator* get_instance();
+
+        friend class MainMenuRegistration;
+        MainMenuRegistration* currentRegistration;
+)

--- a/shared/BSML/FlowCoordinators/MainMenuHolderFlowCoordinator.hpp
+++ b/shared/BSML/FlowCoordinators/MainMenuHolderFlowCoordinator.hpp
@@ -4,6 +4,7 @@
 #include "custom-types/shared/coroutine.hpp"
 #include "HMUI/FlowCoordinator.hpp"
 #include "HMUI/ViewController.hpp"
+#include "../MenuSource.hpp"
 
 namespace BSML {
     class MainMenuRegistration;
@@ -13,13 +14,7 @@ namespace BSML {
 
     class MainMenuRegistration {
         public:
-            enum class RegistrationType {
-                FlowCoordinator,
-                ViewController,
-                Method
-            };
-
-            MainMenuRegistration(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverHint, const System::Type* csType, const RegistrationType registrationType);
+            MainMenuRegistration(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverHint, const System::Type* csType, const MenuSource registrationType);
             MainMenuRegistration(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverHint, const std::function<void(HMUI::ViewController*, bool, bool, bool)> setupFunc);
             ~MainMenuRegistration();
 
@@ -34,7 +29,7 @@ namespace BSML {
             };
             const System::Type* csType;
             const std::function<void(HMUI::ViewController*, bool, bool, bool)> setupFunc;
-            const RegistrationType registrationType;
+            const MenuSource registrationType;
 
             static MainMenuRegistration* get_registration(const std::string_view& buttonText);
         private:

--- a/shared/BSML/GameplaySetup/GameplaySetup.hpp
+++ b/shared/BSML/GameplaySetup/GameplaySetup.hpp
@@ -48,6 +48,8 @@ DECLARE_CLASS_CODEGEN_INTERFACES(BSML, GameplaySetup, Il2CppObject, classof(HMUI
     DECLARE_DEFAULT_CTOR();
     public:
         bool AddTab(std::string_view name, std::string_view content_key, Il2CppObject* host, MenuType menuType = MenuType::All);
+        bool AddTab(System::Type* csType, std::string_view name, MenuType menuType = MenuType::All);
+        bool AddTab(std::function<void(UnityEngine::GameObject*, bool)> didActivate, std::string_view name, MenuType menuType = MenuType::All);
         void SetTabVisibility(std::string_view name, bool isVisible);
         bool RemoveTab(std::string_view name);
 

--- a/shared/BSML/GameplaySetup/GameplaySetupMenu.hpp
+++ b/shared/BSML/GameplaySetup/GameplaySetupMenu.hpp
@@ -3,6 +3,7 @@
 #include "custom-types/shared/macros.hpp"
 #include "../Components/Tab.hpp"
 #include "MenuType.hpp"
+#include "../MenuSource.hpp"
 #include <string>
 
 DECLARE_CLASS_CODEGEN(BSML, GameplaySetupMenu, Il2CppObject,
@@ -11,6 +12,8 @@ DECLARE_CLASS_CODEGEN(BSML, GameplaySetupMenu, Il2CppObject,
     DECLARE_INSTANCE_FIELD(Il2CppObject*, host);
     DECLARE_INSTANCE_FIELD(MenuType, menuType);
     DECLARE_INSTANCE_FIELD(Tab*, tab);
+    DECLARE_INSTANCE_FIELD(MenuSource, menuSource);
+    DECLARE_INSTANCE_FIELD(System::Type*, csType);
 
     DECLARE_INSTANCE_METHOD(bool, get_visible);
     DECLARE_INSTANCE_METHOD(void, set_visible, bool value);
@@ -21,9 +24,12 @@ DECLARE_CLASS_CODEGEN(BSML, GameplaySetupMenu, Il2CppObject,
 
     public:
         static GameplaySetupMenu* Make_new(std::string_view name, std::string_view content_key, Il2CppObject* host, BSML::MenuType menuType = BSML::MenuType::All);
-        bool get_content(std::string_view& content);
+        static GameplaySetupMenu* Make_new(System::Type* csType, std::string_view name, BSML::MenuType menuType = BSML::MenuType::All);
+        static GameplaySetupMenu* Make_new(std::function<void(UnityEngine::GameObject*, bool)> didActivate, std::string_view name, BSML::MenuType menuType = BSML::MenuType::All);
 
+        bool get_content(std::string_view& content);
         bool IsMenuType(BSML::MenuType toCheck);
 
         DECLARE_DEFAULT_CTOR();
+        std::function<void(UnityEngine::GameObject*, bool)> didActivate;
 )

--- a/shared/BSML/GameplaySetup/GameplaySetupTabActivator.hpp
+++ b/shared/BSML/GameplaySetup/GameplaySetupTabActivator.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "custom-types/shared/macros.hpp"
+#include "UnityEngine/MonoBehaviour.hpp"
+#include "../MenuSource.hpp"
+
+DECLARE_CLASS_CODEGEN(BSML, GameplaySetupTabActivator, UnityEngine::MonoBehaviour,
+    DECLARE_INSTANCE_FIELD(MenuSource, menuSource);
+    DECLARE_INSTANCE_FIELD(UnityEngine::MonoBehaviour*, mb);
+    DECLARE_INSTANCE_FIELD(bool, _activatedBefore);
+
+    DECLARE_INSTANCE_METHOD(void, OnEnable);
+    DECLARE_INSTANCE_METHOD(void, OnDisable);
+    public:
+        std::function<void(UnityEngine::GameObject*, bool)> didActivate;
+)

--- a/shared/BSML/MenuSource.hpp
+++ b/shared/BSML/MenuSource.hpp
@@ -6,7 +6,8 @@ namespace BSML {
         BSMLContent,
         FlowCoordinator,
         ViewController,
-        Method
+        Method,
+        Component,
     };
 }
 

--- a/shared/BSML/Settings/BSMLSettings.hpp
+++ b/shared/BSML/Settings/BSMLSettings.hpp
@@ -24,10 +24,15 @@ DECLARE_CLASS_CODEGEN(BSML, BSMLSettings, Il2CppObject,
 
     DECLARE_DEFAULT_CTOR();
     public:
-        bool AddSettingsMenu(std::string_view name, std::string_view content_key, Il2CppObject* host, bool showExtraButtons = false);
+        bool TryAddSettingsMenu(SettingsMenu* menu);
+        bool TryAddSettingsMenu(std::string_view name, std::string_view content_key, Il2CppObject* host, bool showExtraButtons = false);
+        bool TryAddSettingsMenu(System::Type* csType, std::string_view name, MenuSource menuType, bool showExtraButtons = false);
+        bool TryAddSettingsMenu(std::function<void(HMUI::ViewController*, bool, bool, bool)> viewControllerDidActivate, std::string_view name, bool showExtraButtons = false);
+
         bool RemoveSettingsMenu(Il2CppObject* host);
         static BSMLSettings* get_instance();
     protected:
+        void TryAddBSMLMenu();
         custom_types::Helpers::Coroutine AddButtonToMainScreen();
         static SafePtr<BSMLSettings> instance;
 )

--- a/shared/BSML/Settings/MenuSource.hpp
+++ b/shared/BSML/Settings/MenuSource.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "beatsaber-hook/shared/utils/il2cpp-type-check.hpp"
+namespace BSML {
+    enum class MenuSource {
+        BSMLContent,
+        FlowCoordinator,
+        ViewController,
+        Method
+    };
+}
+
+template<>
+struct ::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<BSML::MenuSource> {
+    static inline Il2CppClass* get() {
+        return classof(int);
+    }
+};
+static_assert(sizeof(BSML::MenuSource) == sizeof(int));

--- a/shared/BSML/Settings/SettingsMenu.hpp
+++ b/shared/BSML/Settings/SettingsMenu.hpp
@@ -1,27 +1,39 @@
 #pragma once
 
 #include "custom-types/shared/macros.hpp"
+#include "HMUI/FlowCoordinator.hpp"
 #include "HMUI/ViewController.hpp"
 #include "../Components/CustomListTableData.hpp"
 #include "../Parsing/BSMLParserParams.hpp"
+#include "MenuSource.hpp"
 
 DECLARE_CLASS_CUSTOM(BSML, SettingsMenu, CustomCellInfo,
-    DECLARE_INSTANCE_FIELD(StringW, name);
-    DECLARE_INSTANCE_FIELD(StringW, content_key);
-    DECLARE_INSTANCE_FIELD(Il2CppObject*, host);
-    DECLARE_INSTANCE_FIELD(bool, enableExtraButtons);
-    DECLARE_INSTANCE_FIELD(HMUI::ViewController*, viewController);
-    DECLARE_INSTANCE_METHOD(HMUI::ViewController*, get_viewController);
+    public:
+        DECLARE_INSTANCE_FIELD(StringW, name);
+        DECLARE_INSTANCE_FIELD(StringW, content_key);
+        DECLARE_INSTANCE_FIELD(Il2CppObject*, host);
+        DECLARE_INSTANCE_FIELD(bool, enableExtraButtons);
+        DECLARE_INSTANCE_FIELD(HMUI::ViewController*, viewController);
+        DECLARE_INSTANCE_FIELD(HMUI::FlowCoordinator*, flowCoordinator);
+        DECLARE_INSTANCE_FIELD(System::Type*, csType);
+        DECLARE_INSTANCE_FIELD(MenuSource, menuSource);
 
-    DECLARE_INSTANCE_METHOD(void, Setup);
-    DECLARE_INSTANCE_METHOD(bool, get_didSetup);
+        DECLARE_INSTANCE_METHOD(HMUI::ViewController*, get_viewController);
 
-    DECLARE_DEFAULT_CTOR();
-    DECLARE_SIMPLE_DTOR();
+        DECLARE_INSTANCE_METHOD(void, Setup);
+        DECLARE_INSTANCE_METHOD(bool, get_didSetup);
+
+        DECLARE_DEFAULT_CTOR();
+        DECLARE_SIMPLE_DTOR();
 
     public:
         static SettingsMenu* Make_new(std::string_view name, std::string_view content_key, Il2CppObject* host, bool enableExtraButtons = false);
+        static SettingsMenu* Make_new(std::string_view name, System::Type* viewControllerType, MenuSource menuSource, bool enableExtraButtons = false);
+        static SettingsMenu* Make_new(std::string_view name, std::function<void(HMUI::ViewController*, bool, bool, bool)> viewControllerDidActivate, bool enableExtraButtons);
+
         std::string_view get_content();
         std::shared_ptr<BSMLParserParams> parserParams;
+        std::function<void(HMUI::ViewController*, bool, bool, bool)> viewControllerDidActivate;
+
         static void SetupViewControllerTransform(HMUI::ViewController* viewController);
 )

--- a/shared/BSML/Settings/SettingsMenu.hpp
+++ b/shared/BSML/Settings/SettingsMenu.hpp
@@ -5,7 +5,7 @@
 #include "HMUI/ViewController.hpp"
 #include "../Components/CustomListTableData.hpp"
 #include "../Parsing/BSMLParserParams.hpp"
-#include "MenuSource.hpp"
+#include "../MenuSource.hpp"
 
 DECLARE_CLASS_CUSTOM(BSML, SettingsMenu, CustomCellInfo,
     public:

--- a/src/BSML.cpp
+++ b/src/BSML.cpp
@@ -80,4 +80,8 @@ namespace BSML {
             RegisterMenuButton(reg->buttonText, reg->hoverHint, std::bind(&MainMenuRegistration::Present, reg));
         }
     }
+
+    namespace Events {
+        UnorderedEventCallback<> onGameDidRestart;
+    }
 }

--- a/src/BSML.cpp
+++ b/src/BSML.cpp
@@ -68,6 +68,16 @@ namespace BSML {
             return BSML::GameplaySetup::get_instance()->AddTab(name, content_key, host, menuType);
         }
 
+        bool RegisterGameplaySetupTab(System::Type* csType, std::string_view name, MenuType menuType) {
+            Init();
+            return BSML::GameplaySetup::get_instance()->AddTab(csType, name, menuType);
+        }
+
+        bool RegisterGameplaySetupTab(std::string_view name, std::function<void(UnityEngine::GameObject*, bool)> didActivate, MenuType menuType) {
+            Init();
+            return BSML::GameplaySetup::get_instance()->AddTab(didActivate, name, menuType);
+        }
+
         bool UnRegisterGameplaySetupTab(std::string_view name) {
             Init();
             return BSML::GameplaySetup::get_instance()->RemoveTab(name);

--- a/src/BSML.cpp
+++ b/src/BSML.cpp
@@ -43,7 +43,19 @@ namespace BSML {
 
         bool RegisterSettingsMenu(std::string_view name, std::string_view content_key, Il2CppObject* host, bool enableExtraButtons) {
             Init();
-            return BSMLSettings::get_instance()->AddSettingsMenu(name, content_key, host, enableExtraButtons);
+            return BSMLSettings::get_instance()->TryAddSettingsMenu(name, content_key, host, enableExtraButtons);
+        }
+
+        bool RegisterSettingsMenu(std::string_view name, System::Type* csType, MenuSource menuSource, bool enableExtraButtons) {
+            Init();
+            if (menuSource != BSML::MenuSource::ViewController && menuSource != BSML::MenuSource::FlowCoordinator)
+                throw std::runtime_error("Menu Source was not view controller or flow coordinator!");
+            return BSMLSettings::get_instance()->TryAddSettingsMenu(csType, name, menuSource, enableExtraButtons);
+        }
+
+        bool RegisterSettingsMenu(std::string_view name, std::function<void(HMUI::ViewController*, bool, bool, bool)> viewControllerDidActivate, bool enableExtraButtons) {
+            Init();
+            return BSMLSettings::get_instance()->TryAddSettingsMenu(viewControllerDidActivate, name, enableExtraButtons);
         }
 
         bool UnRegisterSettingsMenu(Il2CppObject* host) {
@@ -62,18 +74,22 @@ namespace BSML {
         }
 
         void RegisterMainMenuFlowCoordinator(const std::string_view& buttonText, const std::string_view& hoverhint, System::Type* flowCoordinatorType) {
+            Init();
             AddMainMenuRegistration(new MainMenuRegistration("", buttonText, hoverhint, flowCoordinatorType, MainMenuRegistration::RegistrationType::FlowCoordinator));
         }
 
         void RegisterMainMenuViewController(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint, System::Type* viewControllerType) {
+            Init();
             AddMainMenuRegistration(new MainMenuRegistration(title, buttonText, hoverhint, viewControllerType, MainMenuRegistration::RegistrationType::ViewController));
         }
 
         void RegisterMainMenuViewControllerMethod(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint, std::function<void(HMUI::ViewController*, bool, bool, bool)> viewControllerDidActivate) {
+            Init();
             AddMainMenuRegistration(new MainMenuRegistration(title, buttonText, hoverhint, viewControllerDidActivate));
         }
 
         void AddMainMenuRegistration(MainMenuRegistration* reg) {
+            Init();
             DEBUG("Registering {}", reg->buttonText);
 
             MainMenuRegistration::registrations.emplace_back(reg);

--- a/src/BSML.cpp
+++ b/src/BSML.cpp
@@ -75,12 +75,12 @@ namespace BSML {
 
         void RegisterMainMenuFlowCoordinator(const std::string_view& buttonText, const std::string_view& hoverhint, System::Type* flowCoordinatorType) {
             Init();
-            AddMainMenuRegistration(new MainMenuRegistration("", buttonText, hoverhint, flowCoordinatorType, MainMenuRegistration::RegistrationType::FlowCoordinator));
+            AddMainMenuRegistration(new MainMenuRegistration("", buttonText, hoverhint, flowCoordinatorType, MenuSource::FlowCoordinator));
         }
 
         void RegisterMainMenuViewController(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint, System::Type* viewControllerType) {
             Init();
-            AddMainMenuRegistration(new MainMenuRegistration(title, buttonText, hoverhint, viewControllerType, MainMenuRegistration::RegistrationType::ViewController));
+            AddMainMenuRegistration(new MainMenuRegistration(title, buttonText, hoverhint, viewControllerType, MenuSource::ViewController));
         }
 
         void RegisterMainMenuViewControllerMethod(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverhint, std::function<void(HMUI::ViewController*, bool, bool, bool)> viewControllerDidActivate) {

--- a/src/BSML/FlowCoordinators/MainMenuHolderFlowCoordinator.cpp
+++ b/src/BSML/FlowCoordinators/MainMenuHolderFlowCoordinator.cpp
@@ -1,0 +1,128 @@
+#include "BSML/FlowCoordinators/MainMenuHolderFlowCoordinator.hpp"
+
+#include "custom-types/shared/delegate.hpp"
+#include "logging.hpp"
+#include "HMUI/ViewController_AnimationDirection.hpp"
+#include "HMUI/ViewController_AnimationType.hpp"
+#include "HMUI/ViewController_DidActivateDelegate.hpp"
+#include "UnityEngine/WaitForEndOfFrame.hpp"
+#include "Helpers/creation.hpp"
+#include "Helpers/getters.hpp"
+
+DEFINE_TYPE(BSML, MainMenuHolderFlowCoordinator);
+
+namespace BSML {
+    SafePtrUnity<MainMenuHolderFlowCoordinator> MainMenuHolderFlowCoordinator::instance;
+    MainMenuHolderFlowCoordinator* MainMenuHolderFlowCoordinator::get_instance() {
+        if (!instance) {
+            instance = BSML::Helpers::CreateFlowCoordinator<MainMenuHolderFlowCoordinator*>();
+        }
+        return instance.ptr();
+    }
+
+    void MainMenuHolderFlowCoordinator::DidActivate(bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling) {
+        if (firstActivation) {
+            showBackButton = true;
+            SetTitle("PlaceHolder", HMUI::ViewController::AnimationType::Out);
+            placeholder = BSML::Helpers::CreateViewController();
+            ProvideInitialViewControllers(placeholder, nullptr, nullptr, nullptr, nullptr);
+        }
+
+        StartCoroutine(custom_types::Helpers::CoroutineHelper::New(EndOfFramePresentVC()));
+    }
+
+    void MainMenuHolderFlowCoordinator::BackButtonWasPressed(HMUI::ViewController* topViewController) {
+        DEBUG("Back Button was pressed");
+        parentFlowCoordinator->DismissFlowCoordinator(this, HMUI::ViewController::AnimationDirection::Horizontal, nullptr, false);
+    }
+
+    custom_types::Helpers::Coroutine MainMenuHolderFlowCoordinator::EndOfFramePresentVC() {
+        co_yield reinterpret_cast<System::Collections::IEnumerator*>(UnityEngine::WaitForEndOfFrame::New_ctor());
+
+        if (currentRegistration) {
+            SetTitle(currentRegistration->title, HMUI::ViewController::AnimationType::Out);
+            if (!mainScreenViewControllers->Contains(currentRegistration->viewController)) {
+                ReplaceTopViewController(currentRegistration->viewController, this, this, nullptr, HMUI::ViewController::AnimationType::In, HMUI::ViewController::AnimationDirection::Horizontal);
+            } else {
+                currentRegistration->viewController->__Activate(false, false);
+            }
+        }
+
+        co_return;
+    }
+
+#pragma region mainMenuregistration
+    std::vector<MainMenuRegistration*> MainMenuRegistration::registrations;
+    MainMenuRegistration* MainMenuRegistration::get_registration(const std::string_view& buttonText) {
+        for (auto reg : registrations)
+            if (reg->buttonText == buttonText) return reg;
+        return nullptr;
+    }
+
+    MainMenuRegistration::MainMenuRegistration(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverHint, const System::Type* csType, const RegistrationType registrationType) :
+        title(title),
+        buttonText(buttonText),
+        hoverHint(hoverHint),
+        csType(csType),
+        setupFunc(nullptr),
+        registrationType(registrationType),
+        viewController(nullptr)
+    {}
+
+    MainMenuRegistration::MainMenuRegistration(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverHint, const std::function<void(HMUI::ViewController*, bool, bool, bool)> setupFunc) :
+        title(title),
+        buttonText(buttonText),
+        hoverHint(hoverHint),
+        csType(csTypeOf(HMUI::ViewController*)),
+        setupFunc(setupFunc),
+        registrationType(RegistrationType::Method),
+        viewController(nullptr)
+    {}
+
+    void MainMenuRegistration::Present() {
+        auto presentOn = BSML::Helpers::GetMainFlowCoordinator()->YoungestChildFlowCoordinatorOrSelf();
+        switch (registrationType) {
+            case RegistrationType::FlowCoordinator:
+                PresentWithFlowCoordinator(presentOn);
+                break;
+            case RegistrationType::ViewController:
+                PresentWithViewController(presentOn);
+                break;
+            case RegistrationType::Method:
+                PresentWithMethod(presentOn);
+                break;
+        }
+    }
+
+    void MainMenuRegistration::PresentWithFlowCoordinator(HMUI::FlowCoordinator* presentOn) {
+        if (!flowCoordinator || !flowCoordinator->m_CachedPtr.m_value) {
+            flowCoordinator = BSML::Helpers::CreateFlowCoordinator(const_cast<System::Type*>(csType));
+        }
+
+        presentOn->PresentFlowCoordinator(flowCoordinator, nullptr, HMUI::ViewController::AnimationDirection::Horizontal, false, false);
+    }
+
+    void MainMenuRegistration::PresentWithViewController(HMUI::FlowCoordinator* presentOn) {
+        if (!viewController || !viewController->m_CachedPtr.m_value) {
+            viewController = BSML::Helpers::CreateViewController(const_cast<System::Type*>(csType));
+        }
+
+        auto fc = MainMenuHolderFlowCoordinator::get_instance();
+        fc->currentRegistration = this;
+
+        presentOn->PresentFlowCoordinator(fc, nullptr, HMUI::ViewController::AnimationDirection::Horizontal, true, false);
+    }
+
+    void MainMenuRegistration::PresentWithMethod(HMUI::FlowCoordinator* presentOn) {
+        if (!viewController || !viewController->m_CachedPtr.m_value) {
+            viewController = BSML::Helpers::CreateViewController(const_cast<System::Type*>(csType));
+            viewController->add_didActivateEvent(custom_types::MakeDelegate<HMUI::ViewController::DidActivateDelegate*>(viewController, setupFunc));
+        }
+
+        auto fc = MainMenuHolderFlowCoordinator::get_instance();
+        fc->currentRegistration = this;
+
+        presentOn->PresentFlowCoordinator(fc, nullptr, HMUI::ViewController::AnimationDirection::Horizontal, true, false);
+    }
+#pragma endregion
+}

--- a/src/BSML/FlowCoordinators/MainMenuHolderFlowCoordinator.cpp
+++ b/src/BSML/FlowCoordinators/MainMenuHolderFlowCoordinator.cpp
@@ -60,7 +60,7 @@ namespace BSML {
         return nullptr;
     }
 
-    MainMenuRegistration::MainMenuRegistration(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverHint, const System::Type* csType, const RegistrationType registrationType) :
+    MainMenuRegistration::MainMenuRegistration(const std::string_view& title, const std::string_view& buttonText, const std::string_view& hoverHint, const System::Type* csType, const MenuSource registrationType) :
         title(title),
         buttonText(buttonText),
         hoverHint(hoverHint),
@@ -77,7 +77,7 @@ namespace BSML {
         hoverHint(hoverHint),
         csType(csTypeOf(HMUI::ViewController*)),
         setupFunc(setupFunc),
-        registrationType(RegistrationType::Method),
+        registrationType(MenuSource::Method),
         viewController(nullptr) {
         BSML::Events::onGameDidRestart += {&MainMenuRegistration::OnGameDidRestart, this};
     }
@@ -97,15 +97,19 @@ namespace BSML {
     void MainMenuRegistration::Present() {
         auto presentOn = BSML::Helpers::GetMainFlowCoordinator()->YoungestChildFlowCoordinatorOrSelf();
         switch (registrationType) {
-            case RegistrationType::FlowCoordinator:
+            case MenuSource::FlowCoordinator:
                 PresentWithFlowCoordinator(presentOn);
                 break;
-            case RegistrationType::ViewController:
+            case MenuSource::ViewController:
                 PresentWithViewController(presentOn);
                 break;
-            case RegistrationType::Method:
+            case MenuSource::Method:
                 PresentWithMethod(presentOn);
                 break;
+            case MenuSource::BSMLContent: [[fallthrough]];
+            case MenuSource::Component:
+                // TODO: should this be supported somehow?
+                throw std::runtime_error("Invalid menu source in main menu registration!");
         }
     }
 

--- a/src/BSML/GameplaySetup/GameplaySetup.cpp
+++ b/src/BSML/GameplaySetup/GameplaySetup.cpp
@@ -133,6 +133,26 @@ namespace BSML {
         return true;
     }
 
+    bool GameplaySetup::AddTab(System::Type* csType, std::string_view name, MenuType menuType) {
+        auto menus = get_menus();
+        auto menu = std::find_if(menus.begin(), menus.end(), [name](auto x){ return reinterpret_cast<GameplaySetupMenu*>(x)->name == name; });
+        if (menu != menus.end()) {
+            return false;
+        }
+        menus->Add(GameplaySetupMenu::Make_new(csType, name, menuType));
+        return true;
+    }
+
+    bool GameplaySetup::AddTab(std::function<void(UnityEngine::GameObject*, bool)> didActivate, std::string_view name, MenuType menuType) {
+        auto menus = get_menus();
+        auto menu = std::find_if(menus.begin(), menus.end(), [name](auto x){ return reinterpret_cast<GameplaySetupMenu*>(x)->name == name; });
+        if (menu != menus.end()) {
+            return false;
+        }
+        menus->Add(GameplaySetupMenu::Make_new(didActivate, name, menuType));
+        return true;
+    }
+
     void GameplaySetup::SetTabVisibility(std::string_view name, bool isVisible) {
         if (!gameplaySetupViewController || !gameplaySetupViewController->m_CachedPtr.m_value || !gameplaySetupViewController->get_isActiveAndEnabled()) {
             return;

--- a/src/BSML/GameplaySetup/GameplaySetupMenu.cpp
+++ b/src/BSML/GameplaySetup/GameplaySetupMenu.cpp
@@ -39,7 +39,7 @@ namespace BSML {
         self->name = name;
         self->menuType = menuType;
         self->didActivate = didActivate;
-        self->menuSource = MenuSource::Component;
+        self->menuSource = MenuSource::Method;
 
         return self;
     }

--- a/src/BSML/GameplaySetup/GameplaySetupMenu.cpp
+++ b/src/BSML/GameplaySetup/GameplaySetupMenu.cpp
@@ -1,4 +1,5 @@
 #include "BSML/GameplaySetup/GameplaySetupMenu.hpp"
+#include "BSML/GameplaySetup/GameplaySetupTabActivator.hpp"
 #include "config.hpp"
 #include "logging.hpp"
 
@@ -16,18 +17,62 @@ namespace BSML {
         self->content_key = content_key;
         self->host = host;
         self->menuType = menuType;
+        self->menuSource = MenuSource::BSMLContent;
 
         return self;
     }
 
+    GameplaySetupMenu* GameplaySetupMenu::Make_new(System::Type* csType, std::string_view name, BSML::MenuType menuType) {
+        auto self = GameplaySetupMenu::New_ctor();
+
+        self->name = name;
+        self->menuType = menuType;
+        self->csType = csType;
+        self->menuSource = MenuSource::Component;
+
+        return self;
+    }
+
+    GameplaySetupMenu* GameplaySetupMenu::Make_new(std::function<void(UnityEngine::GameObject*, bool)> didActivate, std::string_view name, BSML::MenuType menuType) {
+        auto self = GameplaySetupMenu::New_ctor();
+
+        self->name = name;
+        self->menuType = menuType;
+        self->didActivate = didActivate;
+        self->menuSource = MenuSource::Component;
+
+        return self;
+    }
+
+
     void GameplaySetupMenu::Setup() {
-        std::string_view content;
-        if (get_content(content)) {
-            DEBUG("Got content! parsing...");
-            parse_and_construct(content, tab->get_transform(), host);
-        } else { // there was an error
-            DEBUG("Error getting content, was the content key correctly given?");
-            parse_and_construct(content, tab->get_transform(), tab);
+        switch (menuSource) {
+            case MenuSource::BSMLContent: {
+                std::string_view content;
+                if (get_content(content)) {
+                    DEBUG("Got content! parsing...");
+                    parse_and_construct(content, tab->get_transform(), host);
+                } else { // there was an error
+                    DEBUG("Error getting content, was the content key correctly given?");
+                    parse_and_construct(content, tab->get_transform(), tab);
+                }
+                break;
+            }
+            case MenuSource::Method: {
+                    auto activator = tab->get_gameObject()->AddComponent<GameplaySetupTabActivator*>();
+                    activator->didActivate = didActivate;
+                    activator->menuSource = menuSource;
+                }
+                break;
+            case MenuSource::Component: {
+                    auto activator = tab->get_gameObject()->AddComponent<GameplaySetupTabActivator*>();
+                    activator->mb = reinterpret_cast<UnityEngine::MonoBehaviour*>(tab->get_gameObject()->AddComponent(csType));
+                    activator->menuSource = menuSource;
+                }
+                break;
+            case MenuSource::ViewController: [[fallthrough]];
+            case MenuSource::FlowCoordinator:
+                throw std::runtime_error("Invalid menu source passed to gameplay setup!");
         }
     }
 

--- a/src/BSML/GameplaySetup/GameplaySetupTabActivator.cpp
+++ b/src/BSML/GameplaySetup/GameplaySetupTabActivator.cpp
@@ -1,0 +1,33 @@
+#include "BSML/GameplaySetup/GameplaySetupTabActivator.hpp"
+#include "logging.hpp"
+
+DEFINE_TYPE(BSML, GameplaySetupTabActivator);
+
+namespace BSML {
+    void GameplaySetupTabActivator::OnEnable() {
+        switch (menuSource) {
+            case MenuSource::Method:
+                if (didActivate) didActivate(get_gameObject(), !_activatedBefore);
+                break;
+            case MenuSource::Component:
+                if (mb) {
+                    auto* didActivate = il2cpp_functions::class_get_method_from_name(il2cpp_utils::ExtractClass (mb), "DidActivate", 1);
+                    if (didActivate) il2cpp_utils::RunMethod(mb, didActivate, !_activatedBefore);
+                    else ERROR("Class '{}::{}' did not implement 'void DidActivate(bool)' so it could not be called!", mb->klass->namespaze, mb->klass->name);
+                }
+                break;
+            case MenuSource::BSMLContent: [[fallthrough]];
+            case MenuSource::ViewController: [[fallthrough]];
+            case MenuSource::FlowCoordinator:
+                return;
+        }
+        _activatedBefore = true;
+    }
+
+    void GameplaySetupTabActivator::OnDisable() {
+        if (mb && mb->m_CachedPtr.m_value && menuSource == MenuSource::Component) {
+            auto* didDeactivate = il2cpp_functions::class_get_method_from_name(il2cpp_utils::ExtractClass (mb), "DidDeactivate", 0);
+            if (didDeactivate) il2cpp_utils::RunMethod(mb, didDeactivate);
+        }
+    }
+}

--- a/src/BSML/Settings/SettingsMenu.cpp
+++ b/src/BSML/Settings/SettingsMenu.cpp
@@ -8,16 +8,18 @@
 
 #include "UnityEngine/RectTransform.hpp"
 #include "UnityEngine/Vector2.hpp"
+#include "HMUI/ViewController_DidActivateDelegate.hpp"
+#include "custom-types/shared/delegate.hpp"
 
 DEFINE_TYPE(BSML, SettingsMenu);
 
 namespace BSML {
     bool SettingsMenu::get_didSetup() {
-        return viewController && viewController->m_CachedPtr.m_value;
+        return viewController && viewController->m_CachedPtr.m_value || flowCoordinator && flowCoordinator->m_CachedPtr.m_value;
     }
 
     HMUI::ViewController* SettingsMenu::get_viewController() {
-        if (!viewController || !viewController->m_CachedPtr.m_value) {
+        if (!get_didSetup()) {
             Setup();
         }
         return viewController;
@@ -25,10 +27,25 @@ namespace BSML {
 
     void SettingsMenu::Setup() {
         DEBUG("Setup");
-        viewController = Helpers::CreateViewController<HMUI::ViewController*>();
-        SetupViewControllerTransform(viewController);
-        auto parser = parse_and_construct(get_content(), viewController->get_transform(), host);
-        parserParams = parser->parserParams;
+        switch (menuSource) {
+            case MenuSource::BSMLContent:
+                viewController = Helpers::CreateViewController<HMUI::ViewController*>();
+                SetupViewControllerTransform(viewController);
+                parserParams = parse_and_construct(get_content(), viewController->get_transform(), host)->parserParams;
+                break;
+            case MenuSource::FlowCoordinator:
+                flowCoordinator = Helpers::CreateFlowCoordinator(csType);
+                break;
+            case MenuSource::ViewController:
+                viewController = Helpers::CreateViewController(csType);
+                SetupViewControllerTransform(viewController);
+                break;
+            case MenuSource::Method:
+                viewController = Helpers::CreateViewController<HMUI::ViewController*>();
+                SetupViewControllerTransform(viewController);
+                viewController->add_didActivateEvent(custom_types::MakeDelegate<HMUI::ViewController::DidActivateDelegate*>(viewController, viewControllerDidActivate));
+                break;
+        }
     }
 
     std::string_view SettingsMenu::get_content() {
@@ -40,7 +57,7 @@ namespace BSML {
         auto data = entry->get_data();
         return std::string_view(reinterpret_cast<char*>(data.begin()), size_t(data.size()));
     }
-    
+
     void SettingsMenu::SetupViewControllerTransform(HMUI::ViewController* viewController) {
         auto r = viewController->get_rectTransform();
         r->set_sizeDelta({110, 0});
@@ -56,7 +73,33 @@ namespace BSML {
         self->enableExtraButtons = enableExtraButtons;
         self->content_key = content;
         self->host = host;
+        self->menuSource = MenuSource::BSMLContent;
 
         return self;
     }
+
+    SettingsMenu* SettingsMenu::Make_new(std::string_view name, System::Type* csType, MenuSource menuSource, bool enableExtraButtons) {
+        auto self = SettingsMenu::New_ctor();
+
+        self->text = name;
+        self->name = name;
+        self->enableExtraButtons = enableExtraButtons;
+        self->csType = csType;
+        self->menuSource = menuSource;
+
+        return self;
+    }
+
+    SettingsMenu* SettingsMenu::Make_new(std::string_view name, std::function<void(HMUI::ViewController*, bool, bool, bool)> viewControllerDidActivate, bool enableExtraButtons) {
+        auto self = SettingsMenu::New_ctor();
+
+        self->text = name;
+        self->name = name;
+        self->enableExtraButtons = enableExtraButtons;
+        self->viewControllerDidActivate = viewControllerDidActivate;
+        self->menuSource = MenuSource::Method;
+
+        return self;
+    }
+
 }

--- a/src/BSML/Settings/SettingsMenu.cpp
+++ b/src/BSML/Settings/SettingsMenu.cpp
@@ -45,6 +45,8 @@ namespace BSML {
                 SetupViewControllerTransform(viewController);
                 viewController->add_didActivateEvent(custom_types::MakeDelegate<HMUI::ViewController::DidActivateDelegate*>(viewController, viewControllerDidActivate));
                 break;
+            case MenuSource::Component:
+                throw std::runtime_error("Invalid menusource passed to settings menu!");
         }
     }
 

--- a/src/BSML/Settings/UI/ModSettingsFlowCoordinator.cpp
+++ b/src/BSML/Settings/UI/ModSettingsFlowCoordinator.cpp
@@ -57,7 +57,8 @@ namespace BSML {
     void ModSettingsFlowCoordinator::OpenMenu(SettingsMenu* menu) {
         if (!menu->get_didSetup()) {
             menu->Setup();
-            menu->parserParams->AddEvent("back", std::bind(&ModSettingsFlowCoordinator::Back, this));
+            if (menu->menuSource == MenuSource::BSMLContent)
+                menu->parserParams->AddEvent("back", std::bind(&ModSettingsFlowCoordinator::Back, this));
         }
 
         if (bottomButtons && bottomButtons->m_CachedPtr.m_value) {
@@ -67,13 +68,17 @@ namespace BSML {
             }
         }
 
-        OpenMenu(menu->get_viewController(), false, false);
+        if (menu->menuSource == MenuSource::FlowCoordinator) {
+            settingsMenuListViewController->list->tableView->SelectCellWithIdx(0, true);
+            PresentFlowCoordinator(menu->flowCoordinator, nullptr, HMUI::ViewController::AnimationDirection::Horizontal, false, false);
+        } else {
+            OpenMenu(menu->get_viewController(), false, false);
+        }
     }
 
     void ModSettingsFlowCoordinator::OpenMenu(HMUI::ViewController* viewController, bool isSubmenu, bool isBack) {
         if (isPresenting) return;
-        if (!isBack)
-        {
+        if (!isBack) {
             if (isSubmenu)
                 submenuStack->Push(activeController);
             else

--- a/src/Hooks/MenuTransitionsHelper_RestartGame.cpp
+++ b/src/Hooks/MenuTransitionsHelper_RestartGame.cpp
@@ -1,0 +1,12 @@
+#include "hooking.hpp"
+#include "logging.hpp"
+#include "BSML.hpp"
+
+#include "GlobalNamespace/MenuTransitionsHelper.hpp"
+#include "System/Action_1.hpp"
+#include "Zenject/DiContainer.hpp"
+
+MAKE_AUTO_HOOK_MATCH(MenuTransitionsHelper_RestartGame, &GlobalNamespace::MenuTransitionsHelper::RestartGame, void, GlobalNamespace::MenuTransitionsHelper* self, ::System::Action_1<::Zenject::DiContainer*>* finishCallback) {
+    BSML::Events::onGameDidRestart.invoke();
+    MenuTransitionsHelper_RestartGame(self, finishCallback);
+}


### PR DESCRIPTION
Register with methods of the following forms:

`RegisterMainMenu<MyFlowCoordinator*>("button text", "hoverhint");`
`RegisterMainMenu<MyViewController*>("title", "button text", "hoverhint");`
`RegisterMainMenu("title", "button text", "hoverhint", mymethodname);`

and it will show up in the main menu mod button list on the left