### PR TITLE
MainThreadScheduler rework to fix and improve usage

### DIFF
--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -95,12 +95,13 @@
     {
       "dependency": {
         "id": "libil2cpp",
-        "versionRange": "=0.3.1",
+        "versionRange": "=0.3.2",
         "additionalData": {
-          "headersOnly": true
+          "headersOnly": true,
+          "cmake": false
         }
       },
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     {
       "dependency": {

--- a/shared/BSML/MainThreadScheduler.hpp
+++ b/shared/BSML/MainThreadScheduler.hpp
@@ -87,7 +87,7 @@ DECLARE_CLASS_CODEGEN(BSML, MainThreadScheduler, UnityEngine::MonoBehaviour,
             };
 
             static auto InvokeMethod = [](std::shared_future<T> future, std::function<void(T)> method){
-                std::invoke(method, std::forward<T>(future.get()));
+                std::invoke(method, future.get());
             };
 
             ScheduleUntil(std::bind(AwaitFuture, future), std::bind(InvokeMethod, future, method));

--- a/shared/BSML/MainThreadScheduler.hpp
+++ b/shared/BSML/MainThreadScheduler.hpp
@@ -5,6 +5,7 @@
 #include "UnityEngine/MonoBehaviour.hpp"
 #include <queue>
 #include <tuple>
+#include <type_traits>
 
 DECLARE_CLASS_CODEGEN(BSML, MainThreadScheduler, UnityEngine::MonoBehaviour,
     private:
@@ -79,7 +80,7 @@ DECLARE_CLASS_CODEGEN(BSML, MainThreadScheduler, UnityEngine::MonoBehaviour,
         /// @param future the future to await
         /// @param method the method to execute when the future completes
         template<typename T>
-        requires(!std::is_same_v<T, void>)
+        requires(!std::is_same_v<T, void> && std::is_copy_constructible_v<T>)
         static void AwaitFuture(std::shared_future<T> future, std::function<void(T)> method) {
             static auto AwaitFuture = [](std::shared_future<T> future) {
                 return !future.valid() || future.wait_for(std::chrono::nanoseconds(0)) == std::future_status::ready;
@@ -89,7 +90,7 @@ DECLARE_CLASS_CODEGEN(BSML, MainThreadScheduler, UnityEngine::MonoBehaviour,
                 std::invoke(method, std::forward<T>(future.get()));
             };
 
-            ScheduleUntil(std::bind(AwaitFuture, future), std::bind(InvokeMethod, method));
+            ScheduleUntil(std::bind(AwaitFuture, future), std::bind(InvokeMethod, future, method));
         }
 
         /// @brief method to use to await a shared future to complete execution, and binding an instance method to execute when finished, the future result is passed into the method
@@ -97,17 +98,17 @@ DECLARE_CLASS_CODEGEN(BSML, MainThreadScheduler, UnityEngine::MonoBehaviour,
         /// @param method the instance method to execute
         /// @param instance the instance to use for the instance method
         template<typename T, typename U, typename V>
-        requires(std::is_invocable_v<void(U::*)(T), V*, T> && !std::is_same_v<T, void>)
+        requires(std::is_invocable_v<void(U::*)(T), V*, T> && !std::is_same_v<T, void> && std::is_copy_constructible_v<T>)
         static void AwaitFuture(std::shared_future<T> future, void(U::* method)(T), V* instance) {
             static auto AwaitFuture = [](std::shared_future<T> future) {
                 return !future.valid() || future.wait_for(std::chrono::nanoseconds(0)) == std::future_status::ready;
             };
 
             static auto InvokeMethod = [](std::shared_future<T> future, void(U::* method)(T), V* instance){
-                std::invoke(method, std::forward<T>(future.get()), instance);
+                std::invoke(method, instance, future.get());
             };
 
-            ScheduleUntil(std::bind(AwaitFuture, future), std::bind(InvokeMethod, method, instance));
+            ScheduleUntil(std::bind(AwaitFuture, future), std::bind(InvokeMethod, future, method, instance));
         }
 
         /// @brief method that checks whether the thread it's called from is the main thread

--- a/src/BSML/MainThreadScheduler.cpp
+++ b/src/BSML/MainThreadScheduler.cpp
@@ -28,86 +28,106 @@ namespace BSML {
             return;
         }
 
-        std::lock_guard<std::mutex> lock(scheduledMethodsMutex);
+        std::unique_lock lock(scheduledMethodsMutex);
         scheduledMethods.push(method);
     }
 
     void MainThreadScheduler::ScheduleNextFrame(std::function<void()> method) {
-        std::lock_guard<std::mutex> lock(nextFrameScheduledMethodsMutex);
+        std::unique_lock lock(nextFrameScheduledMethodsMutex);
         nextFrameScheduledMethods.push(method);
     }
 
     void MainThreadScheduler::ScheduleAfterTime(float time, std::function<void()> method) {
-        std::lock_guard<std::mutex> lock(scheduledAfterTimeMethodsMutex);
+        std::unique_lock lock(scheduledAfterTimeMethodsMutex);
         scheduledAfterTimeMethods.emplace_back(time, method);
         std::stable_sort(scheduledAfterTimeMethods.begin(), scheduledAfterTimeMethods.end(), [](auto const& a, auto const& b){ return a.first < b.first; });
     }
 
     void MainThreadScheduler::ScheduleUntil(std::function<bool()> until, std::function<void()> method) {
-        std::lock_guard<std::mutex> lock(scheduledUntilMethodsMutex);
+        std::unique_lock lock(scheduledUntilMethodsMutex);
         scheduledUntilMethods.emplace_back(false, until, method);
     }
 
     void MainThreadScheduler::Update() {
         {
-            // acquire lock
-            std::lock_guard<std::mutex> scheduledMethodsLock(scheduledMethodsMutex);
-            // run through our backlog
-            while (!scheduledMethods.empty()) {
-                scheduledMethods.front()();
-                scheduledMethods.pop();
+            // aqcuire lock and swap collection to allow unlocking the collection while it's in use
+            std::unique_lock<std::mutex> lock(scheduledUntilMethodsMutex);
+            decltype(scheduledUntilMethods) iterationVector;
+            iterationVector.swap(scheduledUntilMethods);
+            lock.unlock();
+
+            // go through the collection and see if there are any methods we can invoke
+            int invokedCount = 0;
+            for (auto& [willBeInvoked, until, method] : iterationVector) {
+                if (willBeInvoked) continue;
+                if (!until()) continue;
+
+                // we got a method, push it onto the queue of methods that will already be invoked this frame
+                scheduledMethods.emplace(method);
+                willBeInvoked = true;
+                invokedCount++;
             }
 
-            // aqcuire lock
-            std::lock_guard<std::mutex> nextFrameMethodsLock(nextFrameScheduledMethodsMutex);
-            // push all the nextframe methods onto the scheduled methods queue
-            while(!nextFrameScheduledMethods.empty()) {
-                scheduledMethods.push(nextFrameScheduledMethods.front());
-                nextFrameScheduledMethods.pop();
+            if (invokedCount > 0) {
+                // if anything was invoked we need to remove those
+                // lock collection while we are changing its contents
+                lock.lock();
+                scheduledUntilMethods.reserve(iterationVector.size() - invokedCount);
+                for (auto& v : iterationVector) {
+                    // if the first value of the tuple is true, that means it will be invoked and it should not be kept
+                    if (std::get<0>(v)) continue;
+                    scheduledUntilMethods.emplace_back(std::move(v));
+                }
+                lock.unlock();
             }
         }
+
         {
             // get delta time to use in decreasing timers
             auto delta = UnityEngine::Time::get_deltaTime();
+
             // aqcuire lock for time scheduled methods
-            std::lock_guard<std::mutex> scheduledAfterTimeLock(scheduledAfterTimeMethodsMutex);
+            std::unique_lock scheduledAfterTimeLock(scheduledAfterTimeMethodsMutex);
             // decrease all the timers
             for(auto& [time, func] : scheduledAfterTimeMethods) {
                 time -= delta;
             }
 
-            // if a timer hit below 0, we can invoke the method and remove it
+            // if a timer hit below 0, we can add the method to the collection that will be invoked this frame
             while(!scheduledAfterTimeMethods.empty() && scheduledAfterTimeMethods.front().first <= 0.0f) {
-                scheduledAfterTimeMethods.front().second();
+                scheduledMethods.emplace(scheduledAfterTimeMethods.front().second);
                 scheduledAfterTimeMethods.erase(scheduledAfterTimeMethods.begin());
             }
         }
 
         {
+            // acquire lock and swap with empty vector so we can release the lock during execution
+            std::queue<std::function<void()>> methodsToExecute;
+            std::unique_lock scheduledMethodsLock(scheduledMethodsMutex);
+            methodsToExecute.swap(scheduledMethods);
+
+            // make sure that during invoke, the lock is free
+            scheduledMethodsLock.unlock();
+
+            // run through our backlog
+            while (!methodsToExecute.empty()) {
+                methodsToExecute.front()();
+                methodsToExecute.pop();
+            }
+
             // aqcuire lock
-            std::lock_guard<std::mutex> lock(scheduledUntilMethodsMutex);
+            std::queue<std::function<void()>> methodsToExecuteNextFrame;
+            std::unique_lock<std::mutex> nextFrameMethodsLock(nextFrameScheduledMethodsMutex);
+            methodsToExecuteNextFrame.swap(nextFrameScheduledMethods);
+            nextFrameMethodsLock.unlock();
 
-            // go through the collection and see if there are any methods we can invoke
-            bool anyInvoked = false;
-            for (auto& [invoked, until, method] : scheduledUntilMethods) {
-                if (invoked) continue;
-                if (!until()) continue;
-
-                method();
-                invoked = true;
-                anyInvoked = true;
+            scheduledMethodsLock.lock();
+            // push all the nextframe methods onto the scheduled methods queue so they will be executed next frame
+            while(!nextFrameScheduledMethods.empty()) {
+                scheduledMethods.push(methodsToExecuteNextFrame.front());
+                methodsToExecuteNextFrame.pop();
             }
-
-            // if anything was invoked we need to remove those
-            if (anyInvoked) {
-                decltype(scheduledUntilMethods) newVec;
-                newVec.reserve(scheduledUntilMethods.size());
-                for (auto& v : scheduledUntilMethods) {
-                    if (std::get<0>(v)) continue;
-                    newVec.emplace_back(std::move(v));
-                }
-                scheduledUntilMethods = std::move(newVec);
-            }
+            scheduledMethodsLock.unlock();
         }
     }
 }


### PR DESCRIPTION
 - Fixes AwaitFuture calls so they actually work
 - Rework internals of the MainThreadScheduler::Update method so scheduling things while in scheduled methods works, by swapping contents with temporary things and then adding values back 